### PR TITLE
메인 화면 CSS 스타일 조정

### DIFF
--- a/src/components/Map/Button/ButtonPresenter.tsx
+++ b/src/components/Map/Button/ButtonPresenter.tsx
@@ -8,19 +8,20 @@ interface ButtonPropsInterface {
   onClick?: (e: MouseEvent<HTMLElement, globalThis.MouseEvent>) => void;
 }
 
-const ButtonWrapper = styled.p`
-  text-align: center;
-`;
-
 const Button = styled.button<ButtonPropsInterface>`
   width: ${(props) => props.width};
   height: ${(props) => props.height};
   margin: 5px 0;
-
   border: 0;
-  padding: auto;
   background-color: white;
+  border-radius: 5px;
   box-shadow: 0 0 10px grey;
+  font-weight: 600;
+  color: ${(props) => props.theme.DARKGREY};
+
+  &:hover {
+    color: ${(props) => props.theme.GREEN};
+  }
 `;
 
 function ButtonPresenter({
@@ -30,11 +31,9 @@ function ButtonPresenter({
   onClick,
 }: ButtonPropsInterface): ReactElement {
   return (
-    <ButtonWrapper>
-      <Button width={width} height={height} onClick={onClick}>
-        {textContent}
-      </Button>
-    </ButtonWrapper>
+    <Button width={width} height={height} onClick={onClick}>
+      {textContent}
+    </Button>
   );
 }
 

--- a/src/components/Sidebar/SidebarContentMore/FeatureTypePresenter.tsx
+++ b/src/components/Sidebar/SidebarContentMore/FeatureTypePresenter.tsx
@@ -6,6 +6,9 @@ import data from '../../../utils/redering-data/featureTypeData';
 interface WrapperProps {
   isFeatureName: string;
 }
+interface ListProps {
+  isChecked: boolean;
+}
 
 const FeatureTypeWrapper = styled.ul<WrapperProps>`
   width: ${(props) => (props.isFeatureName ? '250px' : '370px')};
@@ -19,13 +22,13 @@ const FeatureTypeTitle = styled.h2`
   padding-bottom: 20px;
 `;
 
-const FeatureList = styled.li`
+const FeatureList = styled.li<ListProps>`
   width: 100%;
   display: flex;
   font-size: 1.8rem;
   font-weight: 600;
   padding: 10px 0;
-  color: ${(props) => props.theme.GREY};
+  color: ${(props) => (props.isChecked ? props.theme.GREEN : props.theme.GREY)};
   cursor: pointer;
 
   &:hover {
@@ -59,6 +62,7 @@ function FeatureTypePresenter({
         {data.map(({ key, name }) => (
           <FeatureList
             key={key}
+            isChecked={featureName === key}
             onClick={() => {
               featureClickHandler(key);
             }}

--- a/src/components/Sidebar/SidebarFooter/SidebarFooterPresenter.tsx
+++ b/src/components/Sidebar/SidebarFooter/SidebarFooterPresenter.tsx
@@ -3,20 +3,27 @@ import styled from '../../../utils/styles/styled';
 
 const FooterWrapper = styled.footer`
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
-  padding: 15px 10px;
+  padding: 10px;
+  box-shadow: -15px 5px 40px -25px ${(props) => props.theme.BLACK};
 `;
 
 const Button = styled.button`
   position: relative;
   z-index: 10;
-  width: 48%;
-  background-color: ${(props) => props.theme.LIGHTGREY};
+  width: 100px;
+  background-color: white;
   border: none;
   border-radius: 5px;
-  box-shadow: -10px 16px 40px -23px ${(props) => props.theme.BLACK};
   padding: 12px 0;
+  font-size: 1.5em;
+  font-weight: 600;
+  color: ${(props) => props.theme.GREEN};
+
+  &:hover {
+    color: ${(props) => props.theme.BLACK};
+  }
 `;
 
 interface SidebarFooterPresenterProps {

--- a/src/components/Sidebar/SidebarHeader/SidebarHeaderPresenter.tsx
+++ b/src/components/Sidebar/SidebarHeader/SidebarHeaderPresenter.tsx
@@ -4,12 +4,12 @@ import UndoIcon from '../../Icon/UndoIcon';
 import MoreVertIcon from '../../Icon/MoreVertIcon';
 
 const HeaderWrapper = styled.header`
-  height: 5rem;
+  height: 5.5rem;
   width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 12px;
+  padding: 0 15px;
   background-color: ${(props) => props.theme.GREEN};
 `;
 
@@ -30,11 +30,19 @@ const UndoBtn = styled(UndoIcon)`
   margin: 0 0 0 auto;
   fill: white;
   cursor: pointer;
+
+  &:hover {
+    fill: ${(props) => props.theme.DARKGREY};
+  }
 `;
 
 const DropdownBtn = styled(MoreVertIcon)`
   fill: white;
   cursor: pointer;
+
+  &:hover {
+    fill: ${(props) => props.theme.DARKGREY};
+  }
 `;
 
 interface SidebarHeaderPresenterProps {


### PR DESCRIPTION
- 버튼 구분을 위한 스타일 적용과 일부 사이즈 조정을 하였습니다.
- 사이드바 하단 버튼이 어색해보여서 텍스트 형식의 버튼으로 수정했습니다.
![화면 캡처 2020-11-22 141511](https://user-images.githubusercontent.com/41146374/99895757-325ff780-2ccd-11eb-9fd1-a4242a142beb.png)
