### PR TITLE
water / marker에 대한 리듀서 추가 및 타입 수정

### DIFF
--- a/src/components/Sidebar/SidebarContentMore/FeatureTypeItem.tsx
+++ b/src/components/Sidebar/SidebarContentMore/FeatureTypeItem.tsx
@@ -3,6 +3,7 @@ import styled from '../../../utils/styles/styled';
 import {
   FeaturesType,
   FeatureNameType,
+  FeatureNameOneType,
 } from '../../../utils/rendering-data/featureTypeData';
 import useFeatureTypeItemHook from '../../../hooks/sidebar/useFeatureTypeItem';
 
@@ -60,7 +61,7 @@ const Pointer = styled.span`
 `;
 
 interface FeatureTypeItemProps {
-  typeKey: FeatureNameType;
+  typeKey: FeatureNameType | FeatureNameOneType;
   typeName: string;
   features: FeaturesType[];
   sidebarSubTypeName: string;

--- a/src/hooks/sidebar/useDetailType.ts
+++ b/src/hooks/sidebar/useDetailType.ts
@@ -1,6 +1,9 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
-import { FeatureNameType } from '../../utils/rendering-data/featureTypeData';
+import {
+  FeatureNameType,
+  FeatureNameOneType,
+} from '../../utils/rendering-data/featureTypeData';
 import { CommonType, LabelType } from '../../store/common/commonProperties';
 
 interface DetailType {
@@ -17,17 +20,23 @@ interface UseDetailTypeType {
   detail: DetailType;
 }
 
+const dummyDetail = {
+  section: null,
+  label: null,
+};
+
 function useDetailType({
   featureName,
   subFeatureName,
 }: UseDetailTypeProps): UseDetailTypeType {
   const detail = useSelector<RootState>((state) => {
     if (!featureName) {
-      return {
-        section: null,
-        label: null,
-      };
+      return dummyDetail;
     }
+    if (featureName === 'water' || featureName === 'marker') {
+      return state[featureName as FeatureNameOneType];
+    }
+
     return state[featureName as FeatureNameType][subFeatureName];
   }) as DetailType;
 

--- a/src/hooks/sidebar/useFeatureTypeItem.ts
+++ b/src/hooks/sidebar/useFeatureTypeItem.ts
@@ -1,7 +1,10 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import { PoiType } from '../../store/style/poiReducer';
-import { FeatureNameType } from '../../utils/rendering-data/featureTypeData';
+import {
+  FeatureNameType,
+  FeatureNameOneType,
+} from '../../utils/rendering-data/featureTypeData';
 
 interface useFeatureTypeItemType {
   // 나중에 | 연산으로 다양한 타입으로 수정 필요
@@ -9,7 +12,7 @@ interface useFeatureTypeItemType {
 }
 
 export interface useFeatureTypeItemProps {
-  featureName: FeatureNameType;
+  featureName: FeatureNameType | FeatureNameOneType;
 }
 
 function useFeatureTypeItem({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,8 +1,10 @@
 import { combineReducers, createStore } from 'redux';
 import map from './map/reducer';
 import poi from './style/poiReducer';
+import water from './style/waterReducer';
+import marker from './style/markerReducer';
 
-const rootReducer = combineReducers({ map, poi });
+const rootReducer = combineReducers({ map, poi, water, marker });
 const store = createStore(rootReducer);
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/src/store/style/markerReducer.ts
+++ b/src/store/style/markerReducer.ts
@@ -1,0 +1,59 @@
+import {
+  getLabel,
+  getSection,
+  LabelType,
+  CommonType,
+} from '../common/commonProperties';
+
+import {
+  INIT,
+  SET_SECTION,
+  SET_LABEL_TEXT,
+  SET_LABEL_ICON,
+  ActionType,
+} from '../common/action';
+
+export interface MarkerType {
+  isChanged: boolean;
+  section: CommonType;
+  label: LabelType;
+}
+
+const initialState = {
+  isChanged: false,
+  section: getSection(),
+  label: getLabel(),
+};
+
+export default function markerReducer(
+  state: MarkerType = initialState,
+  action: ActionType
+): MarkerType {
+  switch (action.type) {
+    case INIT:
+      return initialState;
+    case SET_SECTION: {
+      const { element, style } = action.payload;
+      const newState = JSON.parse(JSON.stringify(state));
+      newState.section[element as string] = style;
+
+      return newState;
+    }
+    case SET_LABEL_TEXT: {
+      const { element, style } = action.payload;
+      const newState = JSON.parse(JSON.stringify(state));
+      newState.label.text[element as string] = style;
+
+      return newState;
+    }
+    case SET_LABEL_ICON: {
+      const { style } = action.payload;
+      const newState = JSON.parse(JSON.stringify(state));
+      newState.icon = style;
+
+      return newState;
+    }
+    default:
+      return state;
+  }
+}

--- a/src/store/style/waterReducer.ts
+++ b/src/store/style/waterReducer.ts
@@ -1,0 +1,59 @@
+import {
+  getLabel,
+  getSection,
+  LabelType,
+  CommonType,
+} from '../common/commonProperties';
+
+import {
+  INIT,
+  SET_SECTION,
+  SET_LABEL_TEXT,
+  SET_LABEL_ICON,
+  ActionType,
+} from '../common/action';
+
+export interface WaterType {
+  isChanged: boolean;
+  section: CommonType;
+  label: LabelType;
+}
+
+const initialState = {
+  isChanged: false,
+  section: getSection(),
+  label: getLabel(),
+};
+
+export default function waterReducer(
+  state: WaterType = initialState,
+  action: ActionType
+): WaterType {
+  switch (action.type) {
+    case INIT:
+      return initialState;
+    case SET_SECTION: {
+      const { element, style } = action.payload;
+      const newState = JSON.parse(JSON.stringify(state));
+      newState.section[element as string] = style;
+
+      return newState;
+    }
+    case SET_LABEL_TEXT: {
+      const { element, style } = action.payload;
+      const newState = JSON.parse(JSON.stringify(state));
+      newState.label.text[element as string] = style;
+
+      return newState;
+    }
+    case SET_LABEL_ICON: {
+      const { style } = action.payload;
+      const newState = JSON.parse(JSON.stringify(state));
+      newState.icon = style;
+
+      return newState;
+    }
+    default:
+      return state;
+  }
+}

--- a/src/utils/rendering-data/featureTypeData.ts
+++ b/src/utils/rendering-data/featureTypeData.ts
@@ -1,11 +1,12 @@
 export type FeatureNameType = 'poi';
+export type FeatureNameOneType = 'water' | 'marker';
 
 export interface FeaturesType {
   key: string;
   name: string;
 }
 export interface DataType {
-  typeKey: FeatureNameType;
+  typeKey: FeatureNameType | FeatureNameOneType;
   typeName: string;
   features: FeaturesType[];
 }
@@ -68,8 +69,8 @@ const data: DataType[] = [
   //     { key: 'subway', name: '지하철' },
   //   ],
   // },
-  // { typeKey: 'water', typeName: '물', features: [] },
-  // { typeKey: 'mark', typeName: '마크', features: [] },
+  { typeKey: 'water', typeName: '물', features: [] },
+  { typeKey: 'marker', typeName: '마크', features: [] },
 ];
 
 export default data;


### PR DESCRIPTION
## 상세사항
- water / marker리듀서 추가
- 위의 두 feature는 내부에 리스트가 없는 feature임으로 새로운 타입을 만들어주었다.
- 기존 타입을 쓰는 부분에 만든 새로운 타입을 같이 쓰도록 하였다