### PR TITLE
Redux Reduce, Action 리팩토링, 공통 타입 분류, 스타일 전역 상태 조회 Hook 구현

### DIFF
--- a/src/components/Sidebar/SidebarContentMore/DetailType.tsx
+++ b/src/components/Sidebar/SidebarContentMore/DetailType.tsx
@@ -159,7 +159,12 @@ function DetailType({
           />
         </List>
       </DetailWrapper>
-      <Styler detailName={sidebarTypeName} />
+      <Styler
+        featureName={featureName}
+        subFeatureName={subFeatureName}
+        detailName={sidebarTypeName as ElementNameType}
+        subDetailName={sidebarSubTypeName as SubElementNameType}
+      />
     </>
   );
 }

--- a/src/components/Sidebar/SidebarContentMore/DetailType.tsx
+++ b/src/components/Sidebar/SidebarContentMore/DetailType.tsx
@@ -4,10 +4,14 @@ import useSidebarType, {
   SidebarHookType,
 } from '../../../hooks/sidebar/useSidebarType';
 import ListItem, { paddingStepType, paddingStep } from './DetailTypeItem';
-import useDetailType from '../../../hooks/sidebar/useDetailType';
+import useDetailType, {
+  UseDetailHookType,
+} from '../../../hooks/sidebar/useDetailType';
 import Styler from './Styler';
 import {
   FeatureNameType,
+  ElementNameType,
+  SubElementNameType,
 } from '../../../store/common/type';
 
 interface PaddingProp {
@@ -70,12 +74,35 @@ function DetailType({
 }: DetailTypeProps): React.ReactElement {
   const {
     sidebarTypeName,
+    sidebarSubTypeName,
     sidebarTypeClickHandler,
+    sidebarSubTypeClickHandler,
   }: SidebarHookType = useSidebarType();
 
   const {
-    detail: { section, label },
-  } = useDetailType({ featureName, subFeatureName });
+    detail: { section, labelText, labelIcon },
+  }: UseDetailHookType = useDetailType({
+    featureName,
+    subFeatureName,
+  });
+
+  const styleClickHandler = (
+    elementName: ElementNameType,
+    subElementName?: SubElementNameType
+  ) => {
+    sidebarTypeClickHandler(elementName);
+    if (subElementName) sidebarSubTypeClickHandler(subElementName);
+  };
+
+  const getIsSelected = (
+    elementName: ElementNameType,
+    subElementName?: SubElementNameType
+  ) => {
+    if (!subElementName) return sidebarTypeName === elementName;
+    return (
+      sidebarTypeName === elementName && sidebarSubTypeName === subElementName
+    );
+  };
 
   if (!featureName) {
     return <></>;
@@ -89,57 +116,45 @@ function DetailType({
           <Text padding="first">구역</Text>
           {section?.fill.isChanged ? <Check>✓</Check> : <></>}
           <ListItem
-            detailName={sidebarTypeName}
+            isSelected={getIsSelected('section', 'fill')}
             padding="second"
-            clickHandler={(name) => {
-              return sidebarTypeClickHandler(name as FeatureNameType);
-            }}
+            clickHandler={() => styleClickHandler('section', 'fill')}
             name="채우기"
-            parent="구역"
           />
           {section?.stroke.isChanged ? <Check>✓</Check> : <></>}
           <ListItem
-            detailName={sidebarTypeName}
+            isSelected={
+              sidebarTypeName === 'section' && sidebarSubTypeName === 'stroke'
+            }
             padding="second"
-            clickHandler={(name) => {
-              sidebarTypeClickHandler(name as FeatureNameType);
-            }}
+            clickHandler={() => styleClickHandler('section', 'stroke')}
             name="윤곽선"
-            parent="구역"
           />
         </List>
         <List>
           <Text padding="first">라벨</Text>
           <List>
             <Text padding="second">텍스트</Text>
-            {label?.text.fill.isChanged ? <CheckRight>✓</CheckRight> : <></>}
+            {labelText.fill.isChanged ? <CheckRight>✓</CheckRight> : <></>}
             <ListItem
-              detailName={sidebarTypeName}
+              isSelected={getIsSelected('labelText', 'fill')}
               padding="third"
-              clickHandler={(name) => {
-                sidebarTypeClickHandler(name as FeatureNameType);
-              }}
+              clickHandler={() => styleClickHandler('labelText', 'fill')}
               name="채우기"
-              parent="텍스트"
             />
-            {label?.text.stroke.isChanged ? <CheckRight>✓</CheckRight> : <></>}
+            {labelText.stroke.isChanged ? <CheckRight>✓</CheckRight> : <></>}
             <ListItem
-              detailName={sidebarTypeName}
+              isSelected={getIsSelected('labelText', 'stroke')}
               padding="third"
-              clickHandler={(name) => {
-                sidebarTypeClickHandler(name as FeatureNameType);
-              }}
+              clickHandler={() => styleClickHandler('labelText', 'stroke')}
               name="윤곽선"
-              parent="텍스트"
             />
           </List>
-          {label?.icon.isChanged ? <Check>✓</Check> : <></>}
+          {labelIcon.isChanged ? <Check>✓</Check> : <></>}
           <ListItem
-            detailName={sidebarTypeName}
+            isSelected={getIsSelected('labelIcon')}
             padding="second"
-            clickHandler={(name) => {
-              sidebarTypeClickHandler(name as FeatureNameType);
-            }}
+            clickHandler={() => styleClickHandler('labelIcon')}
             name="아이콘"
           />
         </List>

--- a/src/components/Sidebar/SidebarContentMore/DetailType.tsx
+++ b/src/components/Sidebar/SidebarContentMore/DetailType.tsx
@@ -6,7 +6,9 @@ import useSidebarType, {
 import ListItem, { paddingStepType, paddingStep } from './DetailTypeItem';
 import useDetailType from '../../../hooks/sidebar/useDetailType';
 import Styler from './Styler';
-import { FeatureNameType } from '../../../utils/rendering-data/featureTypeData';
+import {
+  FeatureNameType,
+} from '../../../store/common/type';
 
 interface PaddingProp {
   padding: paddingStepType;
@@ -58,7 +60,7 @@ const CheckRight = styled.div`
 `;
 
 interface DetailTypeProps {
-  featureName: string;
+  featureName: FeatureNameType;
   subFeatureName: string;
 }
 

--- a/src/components/Sidebar/SidebarContentMore/DetailTypeItem.tsx
+++ b/src/components/Sidebar/SidebarContentMore/DetailTypeItem.tsx
@@ -4,11 +4,10 @@ import styled from '../../../utils/styles/styled';
 export type paddingStepType = 'first' | 'second' | 'third';
 
 interface ListItemProps {
+  isSelected: boolean;
   padding: paddingStepType;
-  clickHandler: (name: string) => void;
+  clickHandler: () => void;
   name: string;
-  parent?: string;
-  detailName: string;
 }
 
 interface PaddingProp {
@@ -46,20 +45,13 @@ const Item = styled.li<ItemProps>`
 const Pointer = styled.span``;
 
 function DetailTypeItem({
+  isSelected,
   padding,
   clickHandler,
   name,
-  parent,
-  detailName,
 }: ListItemProps): React.ReactElement {
   return (
-    <Item
-      isSelected={detailName === `${parent} ${name}`}
-      padding={padding}
-      onClick={() => {
-        clickHandler(`${parent} ${name}`);
-      }}
-    >
+    <Item isSelected={isSelected} padding={padding} onClick={clickHandler}>
       <span>{name}</span>
       <Pointer>{'>'}</Pointer>
     </Item>

--- a/src/components/Sidebar/SidebarContentMore/FeatureType.tsx
+++ b/src/components/Sidebar/SidebarContentMore/FeatureType.tsx
@@ -6,6 +6,8 @@ import DetailType from './DetailType';
 import useSidebarType, {
   SidebarHookType,
 } from '../../../hooks/sidebar/useSidebarType';
+import { FeatureNameType } from '../../../store/common/type';
+
 import FeatureTypeItem from './FeatureTypeItem';
 
 interface WrapperProps {
@@ -51,7 +53,7 @@ function FeatureType(): React.ReactElement {
         ))}
       </FeatureTypeWrapper>
       <DetailType
-        featureName={sidebarTypeName}
+        featureName={sidebarTypeName as FeatureNameType}
         subFeatureName={sidebarSubTypeName}
       />
     </>

--- a/src/components/Sidebar/SidebarContentMore/FeatureTypeItem.tsx
+++ b/src/components/Sidebar/SidebarContentMore/FeatureTypeItem.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import styled from '../../../utils/styles/styled';
-import {
-  FeaturesType,
-  FeatureNameType,
-  FeatureNameOneType,
-} from '../../../utils/rendering-data/featureTypeData';
+import { FeaturesType } from '../../../utils/rendering-data/featureTypeData';
+import { FeatureNameType } from '../../../store/common/type';
 import useFeatureTypeItemHook from '../../../hooks/sidebar/useFeatureTypeItem';
 
 interface ListProps {
@@ -61,7 +58,7 @@ const Pointer = styled.span`
 `;
 
 interface FeatureTypeItemProps {
-  typeKey: FeatureNameType | FeatureNameOneType;
+  typeKey: FeatureNameType;
   typeName: string;
   features: FeaturesType[];
   sidebarTypeName: string;

--- a/src/components/Sidebar/SidebarContentMore/Styler.tsx
+++ b/src/components/Sidebar/SidebarContentMore/Styler.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
 import styled from '../../../utils/styles/styled';
+import {
+  FeatureNameType,
+  ElementNameType,
+  SubElementNameType,
+} from '../../../store/common/type';
+import useStyleType, {
+  UseStyleHookType,
+} from '../../../hooks/sidebar/useStyleType';
+
 import ColorStyle from './ColorStyle';
 import WeightStyle from './WeightStyle';
 import SaturationStyle from './SaturationStyle';
@@ -31,10 +40,25 @@ const Hr = styled.hr`
 `;
 
 interface StylerProps {
-  detailName: string;
+  featureName: FeatureNameType;
+  subFeatureName: string;
+  detailName: ElementNameType;
+  subDetailName?: SubElementNameType;
 }
 
-function Styler({ detailName }: StylerProps): React.ReactElement {
+function Styler({
+  featureName,
+  subFeatureName,
+  detailName,
+  subDetailName,
+}: StylerProps): React.ReactElement {
+  const { style }: UseStyleHookType = useStyleType({
+    featureName,
+    subFeatureName,
+    detailName,
+    subDetailName,
+  });
+
   if (!detailName) {
     return <></>;
   }

--- a/src/hooks/sidebar/useDetailType.ts
+++ b/src/hooks/sidebar/useDetailType.ts
@@ -3,21 +3,17 @@ import { RootState } from '../../store';
 import {
   FeatureNameType,
   FeatureNameOneType,
-} from '../../utils/rendering-data/featureTypeData';
-import { CommonType, LabelType } from '../../store/common/properties';
-
-interface DetailType {
-  section: CommonType;
-  label: LabelType;
-}
+  FeatureNameMultiType,
+  FeatureType,
+} from '../../store/common/type';
 
 interface UseDetailTypeProps {
-  featureName: string;
+  featureName: FeatureNameType;
   subFeatureName: string;
 }
 
-interface UseDetailTypeType {
-  detail: DetailType;
+export interface UseDetailHookType {
+  detail: FeatureType;
 }
 
 const dummyDetail = {
@@ -28,7 +24,7 @@ const dummyDetail = {
 function useDetailType({
   featureName,
   subFeatureName,
-}: UseDetailTypeProps): UseDetailTypeType {
+}: UseDetailTypeProps): UseDetailHookType {
   const detail = useSelector<RootState>((state) => {
     if (!featureName) {
       return dummyDetail;
@@ -37,8 +33,8 @@ function useDetailType({
       return state[featureName as FeatureNameOneType];
     }
 
-    return state[featureName as FeatureNameType][subFeatureName];
-  }) as DetailType;
+    return state[featureName as FeatureNameMultiType][subFeatureName];
+  }) as FeatureType;
 
   return {
     detail,

--- a/src/hooks/sidebar/useFeatureTypeItem.ts
+++ b/src/hooks/sidebar/useFeatureTypeItem.ts
@@ -1,19 +1,13 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
-import { FeatureState } from '../../store/common/type';
-
-import {
-  FeatureNameType,
-  FeatureNameOneType,
-} from '../../utils/rendering-data/featureTypeData';
+import { FeatureState, FeatureNameType } from '../../store/common/type';
 
 interface useFeatureTypeItemType {
-  // 나중에 | 연산으로 다양한 타입으로 수정 필요
   featureList: FeatureState;
 }
 
 export interface useFeatureTypeItemProps {
-  featureName: FeatureNameType | FeatureNameOneType;
+  featureName: FeatureNameType;
 }
 
 function useFeatureTypeItem({
@@ -21,7 +15,7 @@ function useFeatureTypeItem({
 }: useFeatureTypeItemProps): useFeatureTypeItemType {
   const featureList = useSelector<RootState>(
     (state) => state[featureName]
-  ) as FeatureState; // 나중에 다양한 타입으로 수정 필요
+  ) as FeatureState;
 
   return {
     featureList,

--- a/src/hooks/sidebar/useStyleType.ts
+++ b/src/hooks/sidebar/useStyleType.ts
@@ -1,0 +1,50 @@
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store';
+import {
+  FeatureNameType,
+  FeatureNameOneType,
+  FeatureNameMultiType,
+  StyleType,
+  ElementNameType,
+  SubElementNameType,
+} from '../../store/common/type';
+import { style as dummyStyle } from '../../store/common/properties';
+
+interface UseStyleTypeProps {
+  featureName: FeatureNameType;
+  subFeatureName: string;
+  detailName: ElementNameType;
+  subDetailName?: SubElementNameType;
+}
+
+export interface UseStyleHookType {
+  style: StyleType;
+}
+
+function useStyleType({
+  featureName,
+  subFeatureName,
+  detailName,
+  subDetailName,
+}: UseStyleTypeProps): UseStyleHookType {
+  const style = useSelector<RootState>((state) => {
+    if (!detailName) {
+      return dummyStyle;
+    }
+    let feature;
+    if (featureName === 'water' || featureName === 'marker') {
+      feature = state[featureName as FeatureNameOneType];
+    } else {
+      feature = state[featureName as FeatureNameMultiType][subFeatureName];
+    }
+
+    if (detailName === 'labelIcon') return feature.labelIcon;
+    return feature[detailName][subDetailName as SubElementNameType];
+  }) as StyleType;
+
+  return {
+    style,
+  };
+}
+
+export default useStyleType;

--- a/src/store/common/action.ts
+++ b/src/store/common/action.ts
@@ -1,49 +1,28 @@
-import { StyleType } from './properties';
+import { ActionPayload } from './type';
 
 export const INIT = 'INIT' as const;
+export const SET = 'SET' as const;
 export const SET_SECTION = 'SET_SECTION' as const;
 export const SET_LABEL_TEXT = 'SET_LABEL_TEXT' as const;
 export const SET_LABEL_ICON = 'SET_LABEL_ICON' as const;
 
-export type ElementType = 'fill' | 'stroke';
 export interface SetType {
-  type: typeof SET_SECTION | typeof SET_LABEL_ICON | typeof SET_LABEL_TEXT;
-  payload: {
-    feature: string;
-    element?: ElementType;
-    style: StyleType;
-  };
+  type: typeof SET;
+  payload: ActionPayload;
 }
 
 export const init = (): { type: typeof INIT } => ({
   type: INIT,
 });
 
-export const setSection = (
-  feature: string,
-  element: ElementType,
-  style: StyleType
-): SetType => ({
-  type: SET_SECTION,
-  payload: { feature, style, element },
+export const setStyle = ({
+  feature,
+  element,
+  subElement,
+  style,
+}: ActionPayload): SetType => ({
+  type: SET,
+  payload: { feature, element, subElement, style },
 });
 
-export const setLabelText = (
-  feature: string,
-  element: ElementType,
-  style: StyleType
-): SetType => ({
-  type: SET_LABEL_TEXT,
-  payload: { feature, style, element },
-});
-
-export const setLabelIcon = (feature: string, style: StyleType): SetType => ({
-  type: SET_LABEL_ICON,
-  payload: { feature, style },
-});
-
-export type ActionType =
-  | ReturnType<typeof init>
-  | ReturnType<typeof setSection>
-  | ReturnType<typeof setLabelText>
-  | ReturnType<typeof setLabelIcon>;
+export type ActionType = ReturnType<typeof init> | ReturnType<typeof setStyle>;

--- a/src/store/common/properties.ts
+++ b/src/store/common/properties.ts
@@ -1,23 +1,6 @@
-export interface StyleType {
-  isChanged: boolean;
-  visibility: string;
-  color: string;
-  weight: number;
-  saturation: number;
-  lightness: number;
-}
+import { StyleType, ElementType, FeatureType } from './type';
 
-export interface CommonType {
-  fill: StyleType;
-  stroke: StyleType;
-}
-
-export interface LabelType {
-  text: CommonType;
-  icon: StyleType;
-}
-
-const style: StyleType = {
+export const style: StyleType = {
   isChanged: false,
   visibility: 'inherit',
   color: '#000000',
@@ -26,27 +9,22 @@ const style: StyleType = {
   lightness: 0,
 };
 
-const getStyle = (): StyleType => {
+const getDefaultStyle = (): StyleType => {
   return JSON.parse(JSON.stringify(style));
 };
 
-const label = {
-  text: {
-    fill: getStyle(),
-    stroke: getStyle(),
-  },
-  icon: getStyle(),
+const getDefaultElement = (): ElementType => {
+  return {
+    fill: getDefaultStyle(),
+    stroke: getDefaultStyle(),
+  };
 };
 
-const section = {
-  fill: getStyle(),
-  stroke: getStyle(),
-};
-
-export const getLabel = (): LabelType => {
-  return JSON.parse(JSON.stringify(label));
-};
-
-export const getSection = (): CommonType => {
-  return JSON.parse(JSON.stringify(section));
+export const getDefaultFeature = (): FeatureType => {
+  return {
+    isChanged: false,
+    section: getDefaultElement(),
+    labelText: getDefaultElement(),
+    labelIcon: getDefaultStyle(),
+  };
 };

--- a/src/store/common/reducer.ts
+++ b/src/store/common/reducer.ts
@@ -1,14 +1,8 @@
 import renderingData from '../../utils/rendering-data/featureTypeData';
 
 import { FeatureState } from './type';
-import { getLabel, getSection } from './properties';
-import {
-  INIT,
-  SET_SECTION,
-  SET_LABEL_TEXT,
-  SET_LABEL_ICON,
-  ActionType,
-} from './action';
+import { getDefaultFeature } from './properties';
+import { INIT, SET, ActionType } from './action';
 
 interface ReducerType {
   (state: FeatureState, action: ActionType): FeatureState;
@@ -21,11 +15,7 @@ export default function getReducer(IDX: number): ReducerType {
   ];
 
   const initialState = subFeatures.reduce((acc: FeatureState, cur: string) => {
-    acc[cur] = {
-      isChanged: false,
-      section: getSection(),
-      label: getLabel(),
-    };
+    acc[cur] = getDefaultFeature();
     return acc;
   }, {});
 
@@ -38,31 +28,18 @@ export default function getReducer(IDX: number): ReducerType {
     switch (action.type) {
       case INIT:
         return initialState;
-      case SET_SECTION: {
-        const { feature, element, style } = action.payload;
+      case SET: {
+        const { feature, element, subElement, style } = action.payload;
         if (!featureTypes.includes(feature)) return state;
 
         const newState = JSON.parse(JSON.stringify(state));
-        newState[feature].section[element as string] = style;
 
-        return newState;
-      }
-      case SET_LABEL_TEXT: {
-        const { feature, element, style } = action.payload;
-        if (!featureTypes.includes(feature)) return state;
+        if (element === 'labelIcon') {
+          newState[feature][element] = style;
+          return newState;
+        }
 
-        const newState = JSON.parse(JSON.stringify(state));
-        newState[feature].label.text[element as string] = style;
-
-        return newState;
-      }
-      case SET_LABEL_ICON: {
-        const { feature, style } = action.payload;
-        if (!featureTypes.includes(feature)) return state;
-
-        const newState = JSON.parse(JSON.stringify(state));
-        newState[feature].icon = style;
-
+        newState[feature][element][subElement as string] = style;
         return newState;
       }
       default:

--- a/src/store/common/type.ts
+++ b/src/store/common/type.ts
@@ -1,9 +1,40 @@
-import { LabelType, CommonType } from './properties';
+export type ElementNameType = 'section' | 'labelText' | 'labelIcon';
+export type SubElementNameType = 'fill' | 'stroke';
 
-export interface FeatureState {
-  [name: string]: {
-    isChanged: boolean;
-    section: CommonType;
-    label: LabelType;
-  };
+export type FeatureNameOneType = 'water' | 'marker';
+export type FeatureNameMultiType =
+  | 'poi'
+  | 'administrative'
+  | 'landscape'
+  | 'road'
+  | 'transit';
+export type FeatureNameType = FeatureNameMultiType | FeatureNameOneType;
+
+export interface StyleType {
+  isChanged: boolean;
+  visibility: string;
+  color: string;
+  weight: number;
+  saturation: number;
+  lightness: number;
 }
+export interface ElementType {
+  fill: StyleType;
+  stroke: StyleType;
+}
+export interface FeatureType {
+  isChanged: boolean;
+  section: ElementType;
+  labelText: ElementType;
+  labelIcon: StyleType;
+}
+export interface FeatureState {
+  [name: string]: FeatureType;
+}
+
+export type ActionPayload = {
+  feature: string;
+  element: ElementNameType;
+  subElement?: SubElementNameType;
+  style: StyleType;
+};

--- a/src/store/style/markerReducer.ts
+++ b/src/store/style/markerReducer.ts
@@ -1,62 +1,28 @@
-import {
-  getLabel,
-  getSection,
-  LabelType,
-  CommonType,
-} from '../common/properties';
+import { getDefaultFeature } from '../common/properties';
+import { FeatureType } from '../common/type';
+import { INIT, SET, ActionType } from '../common/action';
 
-import {
-  INIT,
-  SET_SECTION,
-  SET_LABEL_TEXT,
-  SET_LABEL_ICON,
-  ActionType,
-} from '../common/action';
-
-export interface MarkerType {
-  isChanged: boolean;
-  section: CommonType;
-  label: LabelType;
-}
-
-const initialState = {
-  isChanged: false,
-  section: getSection(),
-  label: getLabel(),
-};
+const initialState = getDefaultFeature();
 
 export default function markerReducer(
-  state: MarkerType = initialState,
+  state: FeatureType = initialState,
   action: ActionType
-): MarkerType {
+): FeatureType {
   switch (action.type) {
     case INIT:
       return initialState;
-    case SET_SECTION: {
-      const { feature, element, style } = action.payload;
+    case SET: {
+      const { feature, element, subElement, style } = action.payload;
       if (feature !== 'marker') return state;
 
       const newState = JSON.parse(JSON.stringify(state));
-      newState.section[element as string] = style;
 
-      return newState;
-    }
-    case SET_LABEL_TEXT: {
-      const { feature, element, style } = action.payload;
-      if (feature !== 'marker') return state;
+      if (element === 'labelIcon') {
+        newState[element] = style;
+        return newState;
+      }
 
-      const newState = JSON.parse(JSON.stringify(state));
-      newState.label.text[element as string] = style;
-
-      return newState;
-    }
-    case SET_LABEL_ICON: {
-      const { feature, style } = action.payload;
-      if (feature !== 'marker') return state;
-
-      const newState = JSON.parse(JSON.stringify(state));
-      newState.icon = style;
-
+      newState[element][subElement as string] = style;
       return newState;
     }
     default:

--- a/src/store/style/waterReducer.ts
+++ b/src/store/style/waterReducer.ts
@@ -1,62 +1,28 @@
-import {
-  getLabel,
-  getSection,
-  LabelType,
-  CommonType,
-} from '../common/properties';
+import { getDefaultFeature } from '../common/properties';
+import { FeatureType } from '../common/type';
+import { INIT, SET, ActionType } from '../common/action';
 
-import {
-  INIT,
-  SET_SECTION,
-  SET_LABEL_TEXT,
-  SET_LABEL_ICON,
-  ActionType,
-} from '../common/action';
-
-export interface WaterType {
-  isChanged: boolean;
-  section: CommonType;
-  label: LabelType;
-}
-
-const initialState = {
-  isChanged: false,
-  section: getSection(),
-  label: getLabel(),
-};
+const initialState = getDefaultFeature();
 
 export default function waterReducer(
-  state: WaterType = initialState,
+  state: FeatureType = initialState,
   action: ActionType
-): WaterType {
+): FeatureType {
   switch (action.type) {
     case INIT:
       return initialState;
-    case SET_SECTION: {
-      const { feature, element, style } = action.payload;
+    case SET: {
+      const { feature, element, subElement, style } = action.payload;
       if (feature !== 'water') return state;
 
       const newState = JSON.parse(JSON.stringify(state));
-      newState.section[element as string] = style;
 
-      return newState;
-    }
-    case SET_LABEL_TEXT: {
-      const { feature, element, style } = action.payload;
-      if (feature !== 'water') return state;
+      if (element === 'labelIcon') {
+        newState[element] = style;
+        return newState;
+      }
 
-      const newState = JSON.parse(JSON.stringify(state));
-      newState.label.text[element as string] = style;
-
-      return newState;
-    }
-    case SET_LABEL_ICON: {
-      const { feature, style } = action.payload;
-      if (feature !== 'water') return state;
-
-      const newState = JSON.parse(JSON.stringify(state));
-      newState.icon = style;
-
+      newState[element][subElement as string] = style;
       return newState;
     }
     default:

--- a/src/utils/rendering-data/featureTypeData.ts
+++ b/src/utils/rendering-data/featureTypeData.ts
@@ -1,17 +1,11 @@
-export type FeatureNameOneType = 'water' | 'marker';
-export type FeatureNameType =
-  | 'poi'
-  | 'administrative'
-  | 'landscape'
-  | 'road'
-  | 'transit';
+import { FeatureNameType } from '../../store/common/type';
 
 export interface FeaturesType {
   key: string;
   name: string;
 }
 export interface DataType {
-  typeKey: FeatureNameType | FeatureNameOneType;
+  typeKey: FeatureNameType;
   typeName: string;
   features: FeaturesType[];
 }


### PR DESCRIPTION
- 코드 중복을 야기하고 복잡도를 높혔던 기존 Store의 속성을 수정하였습니다.
- 공통 타입을 분류하면서 관련된 부분을 리팩토링 하였습니다.
- 스타일 사이드바에서 사용하는 전역 상태 조회 Hook을 구현했습니다.

아직 해결하지 못한 버그와 리팩토링 요소가 남아있어서 해당 내용은 커밋에 정리하였습니다. 😂