### PR TITLE
교통(transit) 스타일 조정 기본 기능 구현

### DIFF
--- a/src/hooks/sidebar/useStyleType.ts
+++ b/src/hooks/sidebar/useStyleType.ts
@@ -48,6 +48,7 @@ function useStyleType({
       mapStyling[featureName]({
         map,
         subFeatureName,
+        key,
         detailName,
         subDetailName: subDetailName as SubElementNameType,
         style: {

--- a/src/store/map/layers/transit.ts
+++ b/src/store/map/layers/transit.ts
@@ -1,5 +1,18 @@
 export default [
   {
+    type: 'fill',
+    source: 'composite',
+    'source-layer': 'landuse',
+    layout: {
+      visibility: 'visible',
+    },
+    paint: {
+      'fill-color': 'hsl(230, 100%, 44%)',
+    },
+    filter: ['in', 'class', 'airport'],
+    id: 'transit-airport',
+  },
+  {
     type: 'line',
     source: 'line_source',
     'source-layer': 'line',
@@ -9,7 +22,7 @@ export default [
     paint: {
       'line-color': 'yellow',
     },
-    filter: ['==', ['get', 'type'], 'subway'],
+    filter: ['in', 'type', 'subway'],
     id: 'transit-subway',
   },
   {
@@ -22,7 +35,7 @@ export default [
     paint: {
       'line-color': 'black',
     },
-    filter: ['==', ['get', 'type'], 'rail'],
+    filter: ['in', 'type', 'rail'],
     id: 'transit-rail',
   },
   {
@@ -31,12 +44,15 @@ export default [
     'source-layer': 'poi',
     layout: {
       'text-field': ['get', 'name'],
+      'text-size': 12,
       visibility: 'visible',
     },
     paint: {
-      'text-color': 'green',
+      'text-halo-color': 'green',
+      'text-halo-width': 0.5,
+      'text-color': 'red',
     },
-    filter: ['==', ['get', 'type'], 'taxi'],
-    id: 'transit-bus',
+    filter: ['in', 'type', 'bus_stop'],
+    id: 'transit-bus-label',
   },
 ];

--- a/src/utils/applyStyle.ts
+++ b/src/utils/applyStyle.ts
@@ -1,62 +1,99 @@
+/* eslint-disable no-debugger */
+/* eslint-disable no-case-declarations */
 import mapboxgl from 'mapbox-gl';
+import { StyleKeyName } from '../store/common/type';
 import { hexToHSL } from './colorFormat';
 
-type colorType = 'fill-color' | 'line-color' | 'text-color' | 'text-halo-color';
-type weightType = 'line-width' | 'text-halo-width' | 'text-size';
+export enum VisibilityType {
+  visibility = 'visibility',
+}
+
+export enum ColorTypeName {
+  'fill-color' = 'fill-color',
+  'line-color' = 'line-color',
+  'text-color' = 'text-color',
+  'text-halo-color' = 'text-halo-color',
+}
+export enum WeightTypeName {
+  'line-width' = 'line-width',
+  'text-size' = 'text-size',
+  'text-halo-width' = 'text-halo-width',
+}
+type ColorType = keyof typeof ColorTypeName;
+type WeightType = keyof typeof WeightTypeName;
+export type styleTypes = VisibilityType | ColorType | WeightType;
+
+interface ApplyColorProps {
+  map: mapboxgl.Map;
+  layerNames: string[];
+  color: string;
+  type: styleTypes;
+  saturation?: number;
+  lightness?: number;
+}
 
 export function applyVisibility(
   map: mapboxgl.Map,
-  layerName: string,
+  layerNames: string[],
   visibility: string
 ): void {
-  map.setLayoutProperty(layerName, 'visibility', visibility);
+  return layerNames.forEach((layerName) => {
+    map.setLayoutProperty(layerName, VisibilityType.visibility, visibility);
+  });
 }
 
-export function applyColor(
-  map: mapboxgl.Map,
-  layerName: string,
-  type: colorType,
-  color: string
-): void {
+export function applyColor({
+  map,
+  layerNames,
+  type,
+  color,
+  saturation,
+  lightness,
+}: ApplyColorProps): void {
   const { h, s, l } = hexToHSL(color);
-  map.setPaintProperty(layerName, type, `hsl(${h}, ${s}%, ${l}%)`);
+
+  if (saturation) {
+    return layerNames.forEach((layerName) => {
+      map.setPaintProperty(
+        layerName,
+        type,
+        `hsl(${h}, ${50 + saturation / 2}%, ${l}%)`
+      );
+    });
+  }
+  if (lightness) {
+    return layerNames.forEach((layerName) => {
+      map.setPaintProperty(
+        layerName,
+        type,
+        `hsl(${h}, ${s}%, ${50 + lightness / 2}%)`
+      );
+    });
+  }
+
+  return layerNames.forEach((layerName) => {
+    map.setPaintProperty(layerName, type, `hsl(${h}, ${s}%, ${l}%)`);
+  });
 }
 
 export function applyWeight(
   map: mapboxgl.Map,
-  layerName: string,
-  type: weightType,
-  weight: number
+  layerNames: string[],
+  type: WeightType,
+  weight: string
 ): void {
-  map.setPaintProperty(layerName, type, weight * 2 + 1);
+  return layerNames.forEach((layerName) => {
+    map.setPaintProperty(layerName, type, +weight * 3 + 1);
+  });
 }
 
-export function applySaturation(
+export function applyTextSize(
   map: mapboxgl.Map,
-  layerName: string,
-  type: colorType,
-  color: string,
-  saturation: number
+  layerNames: string[],
+  type: WeightType,
+  size: string
 ): void {
-  const { h, l } = hexToHSL(color);
-  map.setPaintProperty(
-    layerName,
-    type,
-    `hsl(${h}, ${50 + saturation / 2}%, ${l}%)`
-  );
-}
-
-export function applyLightness(
-  map: mapboxgl.Map,
-  layerName: string,
-  type: colorType,
-  color: string,
-  lightness: number
-): void {
-  const { h, s } = hexToHSL(color);
-  map.setPaintProperty(
-    layerName,
-    type,
-    `hsl(${h}, ${s}%, ${50 + lightness / 2}%)`
-  );
+  return layerNames.forEach((layerName) => {
+    map.setLayoutProperty(layerName, type, +size * 3);
+  });
 }

--- a/src/utils/map-styling/index.ts
+++ b/src/utils/map-styling/index.ts
@@ -8,6 +8,7 @@ import {
 export interface stylingProps {
   map: mapboxgl.Map;
   subFeatureName: string;
+  key: string;
   detailName: ElementNameType;
   subDetailName: SubElementNameType;
   style: StyleType;

--- a/src/utils/map-styling/transit.ts
+++ b/src/utils/map-styling/transit.ts
@@ -1,13 +1,151 @@
+/* eslint-disable no-nested-ternary */
+/* eslint-disable no-debugger */
+/* eslint-disable no-case-declarations */
 import { stylingProps } from '.';
+import { StyleKeyName, StyleType } from '../../store/common/type';
+import {
+  applyVisibility,
+  applyColor,
+  applyWeight,
+  applyTextSize,
+  ColorTypeName,
+  styleTypes,
+  WeightTypeName,
+} from '../../utils/applyStyle';
+
+const AirportLayerNames = [
+  'airport-label',
+
+  'aeroway-polygon',
+  'transit-airport',
+  'aeroway-line',
+];
+const BusLayerNames = ['transit-bus-label'];
+const RailLayerNames = ['transit-rail'];
+const SubwayLayerNames = ['transit-subway', 'transit-subway-label'];
+
+const AllLayerTypeKeys = [
+  ...AirportLayerNames,
+  ...BusLayerNames,
+  ...RailLayerNames,
+  ...SubwayLayerNames,
+  'transit-label',
+];
 
 function transitStyling({
   map,
   subFeatureName,
+  key,
   detailName,
   subDetailName,
   style,
 }: stylingProps): void {
-  console.log(1);
+  const layers =
+    subFeatureName === 'all'
+      ? [...AllLayerTypeKeys]
+      : subFeatureName === 'subway'
+      ? [...SubwayLayerNames]
+      : subFeatureName === 'bus'
+      ? [...BusLayerNames]
+      : subFeatureName === 'airport'
+      ? [...AirportLayerNames]
+      : [...RailLayerNames];
+
+  let layersByDetailName: string[];
+  let styleType: styleTypes;
+  debugger;
+  switch (detailName) {
+    case 'section':
+      layersByDetailName = layers.filter((layer) => !layer.includes('label'));
+      styleType =
+        subDetailName === 'stroke'
+          ? key === 'weight'
+            ? WeightTypeName['line-width']
+            : ColorTypeName['line-color']
+          : ColorTypeName['fill-color'];
+
+      break;
+    case 'labelText':
+      layersByDetailName = layers.filter((layer) => layer.includes('label'));
+      styleType =
+        subDetailName === 'stroke'
+          ? key === 'weight'
+            ? WeightTypeName['text-halo-width']
+            : ColorTypeName['text-halo-color']
+          : key === 'weight'
+          ? WeightTypeName['text-size']
+          : ColorTypeName['text-color'];
+      debugger;
+      break;
+    case 'labelIcon':
+      layersByDetailName = layers.filter((layer) => !layer.includes('label'));
+      styleType =
+        subDetailName === 'stroke'
+          ? ColorTypeName['line-color']
+          : ColorTypeName['fill-color'];
+      break;
+
+    default:
+      return;
+  }
+
+  const styleKey: StyleKeyName = key as StyleKeyName;
+  const { [styleKey]: value } = style;
+  let stylerFunction: (obj: any) => void;
+
+  switch (styleKey) {
+    case StyleKeyName.visibility:
+      stylerFunction = ({ layerNames }: { layerNames: string[] }) =>
+        applyVisibility(map, layerNames, value as string);
+      break;
+
+    case StyleKeyName.color:
+    case StyleKeyName.saturation:
+    case StyleKeyName.lightness:
+      const colorKey = StyleKeyName.color;
+      const satKey = StyleKeyName.saturation;
+      const ligKey = StyleKeyName.lightness;
+
+      const satureOrLight =
+        key === 'saturation'
+          ? { saturation: +style[satKey] }
+          : key === 'lightness'
+          ? { lightness: +style[ligKey] }
+          : {};
+      stylerFunction = ({ layerNames }: { layerNames: string[] }) =>
+        applyColor({
+          map,
+          layerNames,
+          type: styleType,
+          color: style[colorKey],
+          ...satureOrLight,
+        });
+      break;
+
+    case StyleKeyName.weight:
+      stylerFunction =
+        subDetailName !== 'fill'
+          ? ({ layerNames }: { layerNames: string[] }) =>
+              applyWeight(
+                map,
+                layerNames,
+                styleType as WeightTypeName,
+                value as string
+              )
+          : ({ layerNames }: { layerNames: string[] }) =>
+              applyTextSize(
+                map,
+                layerNames,
+                styleType as WeightTypeName,
+                value as string
+              );
+      break;
+
+    default:
+      return;
+  }
+
+  stylerFunction({ layerNames: layersByDetailName });
 }
 
 export default transitStyling;


### PR DESCRIPTION
## 구현 결과

![image](https://user-images.githubusercontent.com/57997672/100770207-5b585900-3440-11eb-8f1a-2085d99d5ee8.png)

- 교통 전체/항공/버스/전철/지하철 스타일 조정 기본 기능 구현
  - 샘플 데이터 레이어 + Mapbox 내장 레이어 변경

## TODO
  - 레이어에 없는 속성 변경 시 에러 관련 예외 처리 필요
    - `채우기(fill)`에서 `굵기(weight)` 변경하는 경우 등
    - 일부 경우의 수에서 에러 발생
  - 전반적인 리팩토링 시급

