### PR TITLE
Landscape 부문의 기존 street 테마 속성 변환 기능 구현

### DIFF
--- a/src/store/map/initializeMap.ts
+++ b/src/store/map/initializeMap.ts
@@ -84,9 +84,9 @@ function initializeMap({ mapRef }: InitializeMapProps): mapboxgl.Map {
 
     const layers = [
       ...road,
+      ...landscape,
       ...transit,
       ...water,
-      ...landscape,
       ...mapboxPOI,
       ...poi,
     ] as mapboxgl.Layer[];

--- a/src/utils/map-styling/landscape.ts
+++ b/src/utils/map-styling/landscape.ts
@@ -17,26 +17,13 @@ const SECTION = 'section';
 const LABELTEXT = 'labelText';
 const LABELICON = 'labelIcon';
 
-const ALL = 'all';
-
 type LandscapeSubFeature =
   | 'all'
   | 'human-made'
   | 'building'
   | 'natural'
-  | 'landcover';
-
-const humanMadeLayers: string[] = ['landscape-human-made'];
-
-const buildingLayers: string[] = [
-  'landscape-building',
-  'building-outline',
-  'building',
-];
-
-const naturalLayers: string[] = ['landscape-natural'];
-
-const landcoverLayers: string[] = ['landscape-landcover'];
+  | 'landcover'
+  | 'mountain';
 
 interface SubDetailType {
   fill: string[];
@@ -56,31 +43,69 @@ function makeSubDetail(
   return { fill: fillLayers, stroke: strokeLayers };
 }
 
+const humanMadeSectionFill = ['landscape-human-made'];
+const humanMadeSectionStroke = ['pitch-outline'];
+
+const buildingSectionFill = ['landscape-building', 'building'];
+const buildingSectionStroke = ['building-outline'];
+const buildingLabel = ['building-number-label'];
+
+const naturalSectionFill = ['landscape-natural'];
+const naturalLabel = ['natural-point-label'];
+
+const landCoverSectionFill = [
+  'landscape-landcover',
+  'landcover',
+  'landuse',
+  'lang-structure-polygon',
+];
+const landCoverSectionStroke = ['lang-structure-line'];
+
+const mountainCoverSectionFill = ['hillshade'];
+
 const layersByType: { [key in LandscapeSubFeature]: DetailType } = {
   'human-made': {
-    [SECTION]: makeSubDetail([], []),
+    [SECTION]: makeSubDetail(humanMadeSectionFill, humanMadeSectionStroke),
     [LABELTEXT]: makeSubDetail([], []),
     [LABELICON]: makeSubDetail([], []),
   },
   building: {
-    [SECTION]: makeSubDetail([], []),
+    [SECTION]: makeSubDetail(buildingSectionFill, buildingSectionStroke),
     [LABELTEXT]: makeSubDetail([], []),
-    [LABELICON]: makeSubDetail([], []),
+    [LABELICON]: makeSubDetail(buildingLabel, buildingLabel),
   },
   natural: {
-    [SECTION]: makeSubDetail([], []),
+    [SECTION]: makeSubDetail(naturalSectionFill, []),
+    [LABELTEXT]: makeSubDetail([], []),
+    [LABELICON]: makeSubDetail(naturalLabel, naturalLabel),
+  },
+  landcover: {
+    [SECTION]: makeSubDetail(landCoverSectionFill, landCoverSectionStroke),
     [LABELTEXT]: makeSubDetail([], []),
     [LABELICON]: makeSubDetail([], []),
   },
-  landcover: {
-    [SECTION]: makeSubDetail([], []),
+  mountain: {
+    [SECTION]: makeSubDetail(mountainCoverSectionFill, []),
     [LABELTEXT]: makeSubDetail([], []),
     [LABELICON]: makeSubDetail([], []),
   },
   all: {
-    [SECTION]: makeSubDetail([], []),
+    [SECTION]: makeSubDetail(
+      [
+        ...humanMadeSectionFill,
+        ...buildingSectionFill,
+        ...naturalSectionFill,
+        ...landCoverSectionFill,
+        ...mountainCoverSectionFill,
+      ],
+      [
+        ...humanMadeSectionStroke,
+        ...buildingSectionStroke,
+        ...landCoverSectionStroke,
+      ]
+    ),
     [LABELTEXT]: makeSubDetail([], []),
-    [LABELICON]: makeSubDetail([], []),
+    [LABELICON]: makeSubDetail([], [...buildingLabel, ...naturalLabel]),
   },
 };
 
@@ -235,8 +260,6 @@ function landscapeStyling({
   let type = null;
   let func = null;
 
-  console.log(subFeatureName, detailName, subDetailName, key);
-
   if (
     detailName === ElementNameType.section ||
     detailName === ElementNameType.labelText
@@ -273,7 +296,6 @@ function landscapeStyling({
     return;
   }
   if (key === 'visibility') {
-    console.log(func);
     func({
       map,
       layerNames:

--- a/src/utils/map-styling/landscape.ts
+++ b/src/utils/map-styling/landscape.ts
@@ -1,6 +1,6 @@
 import { stylingProps } from './index';
 import { applyColor, applyVisibility, ColorType } from '../applyStyle';
-import { StyleType } from '../../store/common/type';
+import { StyleKeyType, StyleType } from '../../store/common/type';
 
 const SECTION = 'section';
 const FILL = 'fill';
@@ -11,28 +11,51 @@ const layers = ['human-made', 'building', 'natural', 'landcover'];
 interface applyStyleProps {
   map: mapboxgl.Map;
   subFeatureName: string;
+  key: StyleKeyType;
   style: StyleType;
 }
 
-function applyLandscapeStyle({ map, subFeatureName, style }: applyStyleProps) {
+function applyLandscapeStyle({
+  map,
+  subFeatureName,
+  key,
+  style,
+}: applyStyleProps): void {
   const layerNames = [`landscape-${subFeatureName}`];
 
-  applyColor({ map, layerNames, type: ColorType.fill, color: style.color });
-  applyVisibility({ map, layerNames, visibility: style.visibility });
-  applyColor({
-    map,
-    layerNames,
-    type: ColorType.fill,
-    color: style.color,
-    lightness: Number(style.lightness),
-  });
-  applyColor({
-    map,
-    layerNames,
-    type: ColorType.fill,
-    color: style.color,
-    saturation: Number(style.saturation),
-  });
+  switch (key) {
+    case 'color':
+      applyColor({
+        map,
+        layerNames,
+        type: ColorType.fill,
+        color: style.color,
+      });
+      break;
+    case 'visibility':
+      applyVisibility({ map, layerNames, visibility: style.visibility });
+      break;
+    case 'lightness':
+      applyColor({
+        map,
+        layerNames,
+        type: ColorType.fill,
+        color: style.color,
+        lightness: Number(style.lightness),
+      });
+      break;
+    case 'saturation':
+      applyColor({
+        map,
+        layerNames,
+        type: ColorType.fill,
+        color: style.color,
+        saturation: Number(style.saturation),
+      });
+      break;
+    default:
+      break;
+  }
 }
 
 function landscapeStyling({
@@ -40,6 +63,7 @@ function landscapeStyling({
   subFeatureName,
   detailName,
   subDetailName,
+  key,
   style,
 }: stylingProps): void {
   if (detailName !== SECTION || subDetailName !== FILL) {
@@ -48,10 +72,10 @@ function landscapeStyling({
 
   if (subFeatureName === ALL) {
     layers.forEach((item) =>
-      applyLandscapeStyle({ map, subFeatureName: item, style })
+      applyLandscapeStyle({ map, subFeatureName: item, key, style })
     );
   } else {
-    applyLandscapeStyle({ map, subFeatureName, style });
+    applyLandscapeStyle({ map, subFeatureName, key, style });
   }
 }
 

--- a/src/utils/map-styling/landscape.ts
+++ b/src/utils/map-styling/landscape.ts
@@ -1,62 +1,228 @@
 import { stylingProps } from './index';
-import { applyColor, applyVisibility, ColorType } from '../applyStyle';
-import { StyleKeyType, StyleType } from '../../store/common/type';
+import {
+  applyColor,
+  applyWeight,
+  applyVisibility,
+  WeightType,
+  ColorType,
+  StyleTypes,
+} from '../applyStyle';
+import {
+  StyleKeyType,
+  ElementNameType,
+  StyleType,
+} from '../../store/common/type';
 
 const SECTION = 'section';
-const FILL = 'fill';
+const LABELTEXT = 'labelText';
+const LABELICON = 'labelIcon';
+
 const ALL = 'all';
 
-const layers = ['human-made', 'building', 'natural', 'landcover'];
+type LandscapeSubFeature =
+  | 'all'
+  | 'human-made'
+  | 'building'
+  | 'natural'
+  | 'landcover';
 
-interface applyStyleProps {
-  map: mapboxgl.Map;
-  subFeatureName: string;
-  key: StyleKeyType;
-  style: StyleType;
+const humanMadeLayers: string[] = ['landscape-human-made'];
+
+const buildingLayers: string[] = [
+  'landscape-building',
+  'building-outline',
+  'building',
+];
+
+const naturalLayers: string[] = ['landscape-natural'];
+
+const landcoverLayers: string[] = ['landscape-landcover'];
+
+interface SubDetailType {
+  fill: string[];
+  stroke: string[];
 }
 
-function applyLandscapeStyle({
-  map,
-  subFeatureName,
-  key,
-  style,
-}: applyStyleProps): void {
-  const layerNames = [`landscape-${subFeatureName}`];
-
-  switch (key) {
-    case 'color':
-      applyColor({
-        map,
-        layerNames,
-        type: ColorType.fill,
-        color: style.color,
-      });
-      break;
-    case 'visibility':
-      applyVisibility({ map, layerNames, visibility: style.visibility });
-      break;
-    case 'lightness':
-      applyColor({
-        map,
-        layerNames,
-        type: ColorType.fill,
-        color: style.color,
-        lightness: Number(style.lightness),
-      });
-      break;
-    case 'saturation':
-      applyColor({
-        map,
-        layerNames,
-        type: ColorType.fill,
-        color: style.color,
-        saturation: Number(style.saturation),
-      });
-      break;
-    default:
-      break;
-  }
+interface DetailType {
+  section: SubDetailType;
+  labelText: SubDetailType;
+  labelIcon: SubDetailType;
 }
+
+function makeSubDetail(
+  fillLayers: string[],
+  strokeLayers: string[]
+): SubDetailType {
+  return { fill: fillLayers, stroke: strokeLayers };
+}
+
+const layersByType: { [key in LandscapeSubFeature]: DetailType } = {
+  'human-made': {
+    [SECTION]: makeSubDetail([], []),
+    [LABELTEXT]: makeSubDetail([], []),
+    [LABELICON]: makeSubDetail([], []),
+  },
+  building: {
+    [SECTION]: makeSubDetail([], []),
+    [LABELTEXT]: makeSubDetail([], []),
+    [LABELICON]: makeSubDetail([], []),
+  },
+  natural: {
+    [SECTION]: makeSubDetail([], []),
+    [LABELTEXT]: makeSubDetail([], []),
+    [LABELICON]: makeSubDetail([], []),
+  },
+  landcover: {
+    [SECTION]: makeSubDetail([], []),
+    [LABELTEXT]: makeSubDetail([], []),
+    [LABELICON]: makeSubDetail([], []),
+  },
+  all: {
+    [SECTION]: makeSubDetail([], []),
+    [LABELTEXT]: makeSubDetail([], []),
+    [LABELICON]: makeSubDetail([], []),
+  },
+};
+
+const VISIBLE = 1;
+const INVISIBLE = 0;
+
+const mappingDetailToFunc = {
+  labelText: {
+    fill: {
+      color: {
+        typeName: ColorType.text,
+        funcName: applyColor,
+      },
+      saturation: {
+        typeName: ColorType.text,
+        funcName: applyColor,
+      },
+      lightness: {
+        typeName: ColorType.text,
+        funcName: applyColor,
+      },
+      weight: {
+        typeName: null,
+        funcName: () => null,
+      },
+      visibility: {
+        typeName: 'what is my name?',
+        funcName: applyVisibility,
+      },
+      isChanged: {
+        typeName: null,
+        funcName: () => null,
+      },
+    },
+    stroke: {
+      color: {
+        typeName: ColorType.textHalo,
+        funcName: applyColor,
+      },
+      saturation: {
+        typeName: ColorType.textHalo,
+        funcName: applyColor,
+      },
+      lightness: {
+        typeName: ColorType.textHalo,
+        funcName: applyColor,
+      },
+      weight: {
+        typeName: WeightType.textHalo,
+        funcName: applyWeight,
+      },
+      visibility: {
+        typeName: WeightType.textHalo,
+        funcName: applyWeight,
+      },
+      isChanged: {
+        typeName: null,
+        funcName: () => null,
+      },
+    },
+  },
+  labelIcon: {
+    color: {
+      typeName: null,
+      funcName: () => null,
+    },
+    saturation: {
+      typeName: null,
+      funcName: () => null,
+    },
+    lightness: {
+      typeName: null,
+      funcName: () => null,
+    },
+    weight: {
+      typeName: null,
+      funcName: () => null,
+    },
+    visibility: {
+      typeName: ColorType.icon,
+      funcName: applyWeight,
+    },
+    isChanged: {
+      typeName: null,
+      funcName: () => null,
+    },
+  },
+  section: {
+    fill: {
+      color: {
+        typeName: ColorType.fill,
+        funcName: applyColor,
+      },
+      saturation: {
+        typeName: ColorType.fill,
+        funcName: applyColor,
+      },
+      lightness: {
+        typeName: ColorType.fill,
+        funcName: applyColor,
+      },
+      weight: {
+        typeName: null,
+        funcName: () => null,
+      },
+      visibility: {
+        typeName: ColorType.fill,
+        funcName: applyVisibility,
+      },
+      isChanged: {
+        typeName: null,
+        funcName: () => null,
+      },
+    },
+    stroke: {
+      color: {
+        typeName: ColorType.line,
+        funcName: applyColor,
+      },
+      saturation: {
+        typeName: ColorType.line,
+        funcName: applyColor,
+      },
+      lightness: {
+        typeName: ColorType.line,
+        funcName: applyColor,
+      },
+      weight: {
+        typeName: WeightType.line,
+        funcName: applyWeight,
+      },
+      visibility: {
+        typeName: WeightType.line,
+        funcName: applyVisibility,
+      },
+      isChanged: {
+        typeName: null,
+        funcName: () => null,
+      },
+    },
+  },
+};
 
 function landscapeStyling({
   map,
@@ -66,17 +232,68 @@ function landscapeStyling({
   key,
   style,
 }: stylingProps): void {
-  if (detailName !== SECTION || subDetailName !== FILL) {
-    return;
+  let type = null;
+  let func = null;
+
+  console.log(subFeatureName, detailName, subDetailName, key);
+
+  if (
+    detailName === ElementNameType.section ||
+    detailName === ElementNameType.labelText
+  ) {
+    const { typeName, funcName } = mappingDetailToFunc[detailName][
+      subDetailName
+    ][key as StyleKeyType];
+    type = typeName;
+    func = funcName;
+  } else {
+    const { typeName, funcName } = mappingDetailToFunc[detailName][
+      key as StyleKeyType
+    ];
+    type = typeName;
+    func = funcName;
   }
 
-  if (subFeatureName === ALL) {
-    layers.forEach((item) =>
-      applyLandscapeStyle({ map, subFeatureName: item, key, style })
-    );
-  } else {
-    applyLandscapeStyle({ map, subFeatureName, key, style });
+  if (!type) {
+    return;
   }
+  if (
+    key === 'visibility' &&
+    (type === ColorType.icon || type === WeightType.textHalo)
+  ) {
+    func({
+      map,
+      layerNames:
+        layersByType[subFeatureName as LandscapeSubFeature][detailName][
+          subDetailName
+        ],
+      type,
+      weight: style.visibility === 'none' ? INVISIBLE : VISIBLE,
+    });
+    return;
+  }
+  if (key === 'visibility') {
+    console.log(func);
+    func({
+      map,
+      layerNames:
+        layersByType[subFeatureName as LandscapeSubFeature][detailName][
+          subDetailName
+        ],
+      visibility: style.visibility,
+    });
+  }
+
+  func({
+    map,
+    layerNames:
+      layersByType[subFeatureName as LandscapeSubFeature][detailName][
+        subDetailName
+      ],
+    type: type as StyleTypes,
+    color: style.color,
+    [key]: style[key as StyleKeyType],
+  });
 }
 
 export default landscapeStyling;


### PR DESCRIPTION
![landscape](https://user-images.githubusercontent.com/46532449/100915240-6df19180-3517-11eb-9c2b-0859d2b34798.png)

위의 스크린샷은 경관 항목 전체 탭에서 모든 항목을 검정색으로 변환한 뒤 촬영하였습니다. 

## 구현 상황
* 폴리곤만으로 이루어지는 줄 알았던 landscape가 라벨 등등을 다 다뤄야한다는 것을 깨달아버렸습니다
  * #93 을 참조하여 최대한 일관성을 가질 수 있게 작성하였습니다. mappingDetailToFunc는 src\utils\map-styling\poi.ts의 동명의 객체에서 section 이후 부분만이 더해진 것임을 확인할 수 있습니다. 
  * polygon, line 등을 구분하는 것은 객체를 하나 생성한 뒤 이 안에서 인자로 주어진 subFeatureName, detailName, subDetailName를 입력하면 배열을 주도록 하였습니다.

## Todo
* 현재 정확히 확인이 어려우나, 지붕을 위해 만들어진 부분 등 완전히 변환이 되지 않는 것으로 추측되는 부분이 몇 있습니다. 스크린샷에서도 이를 확인하실 수 있습니다. (만일 가능하다면) 이후에 어느 구역에 속하는지 확인하고 수정해보겠습니다. 