### PR TITLE
Sidebar Feature/Element 선택 상태 저장 기능 구현(진행중)

### DIFF
--- a/src/hooks/sidebar/useSidebarType.ts
+++ b/src/hooks/sidebar/useSidebarType.ts
@@ -1,4 +1,16 @@
 import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  setFeature,
+  setSubFeature,
+  setElement,
+  setSubElement,
+} from '../../store/sidebar/action';
+import {
+  FeatureNameType,
+  ElementNameType,
+  SubElementNameType,
+} from '../../store/common/type';
 
 export interface SidebarHookType {
   sidebarTypeClickHandler: (name: string) => void;
@@ -10,15 +22,33 @@ export interface SidebarHookType {
 function useSidebarType(): SidebarHookType {
   const [sidebarTypeName, setSidebarTypeName] = useState<string>('');
   const [sidebarSubTypeName, setSidebarSubTypeName] = useState<string>('');
+  const dispatch = useDispatch();
 
   const sidebarTypeClickHandler = (name: string) => {
     if (name !== sidebarTypeName) {
+      if (
+        name === ElementNameType.section ||
+        name === ElementNameType.labelText ||
+        name === ElementNameType.labelIcon
+      ) {
+        dispatch(setElement(name as ElementNameType));
+      } else {
+        dispatch(setFeature(name as FeatureNameType));
+      }
       setSidebarTypeName(name);
     }
   };
 
   const sidebarSubTypeClickHandler = (name: string) => {
     if (name !== sidebarSubTypeName) {
+      if (
+        name === SubElementNameType.fill ||
+        name === SubElementNameType.stroke
+      ) {
+        dispatch(setSubElement(name));
+      } else {
+        dispatch(setSubFeature(name));
+      }
       setSidebarSubTypeName(name);
     }
   };

--- a/src/store/common/type.ts
+++ b/src/store/common/type.ts
@@ -1,4 +1,10 @@
 import { init, setStyle } from '../style/action';
+import {
+  setFeature,
+  setSubFeature,
+  setElement,
+  setSubElement,
+} from '../sidebar/action';
 
 export type hello = 'landmark';
 
@@ -70,6 +76,11 @@ export interface ElementPropsType extends FeaturePropsType {
 }
 
 export type ActionType = ReturnType<typeof init> | ReturnType<typeof setStyle>;
+export type SidebarActionType =
+  | ReturnType<typeof setFeature>
+  | ReturnType<typeof setSubFeature>
+  | ReturnType<typeof setElement>
+  | ReturnType<typeof setSubElement>;
 
 export interface ActionPayload extends ElementPropsType {
   style: StyleType;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,6 +10,7 @@ import {
   waterReducer as water,
   markerReducer as marker,
 } from './style/reducer';
+import sidebar from './sidebar/reducer';
 
 const rootReducer = combineReducers({
   map,
@@ -20,6 +21,7 @@ const rootReducer = combineReducers({
   transit,
   water,
   marker,
+  sidebar,
 });
 
 const store = createStore(rootReducer);

--- a/src/store/sidebar/action.ts
+++ b/src/store/sidebar/action.ts
@@ -1,0 +1,46 @@
+import {
+  FeatureNameType,
+  ElementNameType,
+  SubElementNameType,
+} from '../common/type';
+
+export const SET_FEATURE = 'SET_FEATURE' as const;
+export const SET_SUBFEATURE = 'SET_SUBFEATURE' as const;
+export const SET_ELEMENT = 'SET_ELEMENT' as const;
+export const SET_SUBELEMENT = 'SET_SUBELEMENT' as const;
+
+export interface SidebarActionType {
+  type:
+    | typeof SET_FEATURE
+    | typeof SET_SUBFEATURE
+    | typeof SET_ELEMENT
+    | typeof SET_SUBELEMENT;
+  payload: {
+    feature?: FeatureNameType;
+    subFeature?: string;
+    element?: ElementNameType;
+    subElement?: SubElementNameType;
+  };
+}
+
+export const setFeature = (feature: FeatureNameType): SidebarActionType => ({
+  type: SET_FEATURE,
+  payload: { feature },
+});
+
+export const setSubFeature = (subFeature: string): SidebarActionType => ({
+  type: SET_SUBFEATURE,
+  payload: { subFeature },
+});
+
+export const setElement = (element: ElementNameType): SidebarActionType => ({
+  type: SET_ELEMENT,
+  payload: { element },
+});
+
+export const setSubElement = (
+  subElement: SubElementNameType
+): SidebarActionType => ({
+  type: SET_SUBELEMENT,
+  payload: { subElement },
+});

--- a/src/store/sidebar/reducer.ts
+++ b/src/store/sidebar/reducer.ts
@@ -1,0 +1,63 @@
+import {
+  FeatureNameType,
+  ElementNameType,
+  SubElementNameType,
+  SidebarActionType,
+} from '../common/type';
+import {
+  SET_FEATURE,
+  SET_SUBFEATURE,
+  SET_ELEMENT,
+  SET_SUBELEMENT,
+} from './action';
+
+interface SidebarStateType {
+  feature?: FeatureNameType | '';
+  subFeature?: string;
+  element?: ElementNameType | '';
+  subElement?: SubElementNameType | '';
+}
+
+const initialState: SidebarStateType = {
+  feature: '',
+  subFeature: '',
+  element: '',
+  subElement: '',
+};
+
+function sidebarReducer(
+  state: SidebarStateType = initialState,
+  action: SidebarActionType
+): SidebarStateType {
+  switch (action.type) {
+    case SET_FEATURE: {
+      return {
+        ...state,
+        feature: action.payload.feature,
+      };
+    }
+    case SET_SUBFEATURE: {
+      return {
+        ...state,
+        subFeature: action.payload.subFeature,
+      };
+    }
+    case SET_ELEMENT: {
+      return {
+        ...state,
+        element: action.payload.element,
+      };
+    }
+    case SET_SUBELEMENT: {
+      return {
+        ...state,
+
+        subElement: action.payload.subElement,
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+export default sidebarReducer;


### PR DESCRIPTION
## 구현 결과

### Sidebar 상태 저장 위한 action/reducer 

- 6f8db71
- Feature/Element 선택 내용에 대한 상태 저장

### Sidebar action type 지정 및 store 저장

- 5cb852c

### sidebar hooks에 action 및 dispatcher 등록 

- 4f60cde
- 각각의 Type/SubType에 맞는 action 등록

---

## TODO

- 기존 hooks로 넘겨주던 부분 대체