### PR TITLE
 현재 선택한 사이드바의 항목을 상태로 분리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2491,6 +2491,12 @@
         "@types/node": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
+      "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==",
+      "dev": true
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -2617,6 +2623,27 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.8.tgz",
+      "integrity": "sha512-HzOyJb+wFmyEhyfp4D4NYrumi+LQgQL/68HvJO+q6XtuHSDvw6Aqov7sCAhjbNq3bUPgPqbdvjXC5HeB2oEAPg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.6.tgz",
+      "integrity": "sha512-gjrxYqxz37zWEdMVvQtWPFMFj1dRDb4TGOcgyOfSXTrEXdF92L00WE3C471O3TV/RF1oskcStkXsOU0Ete4s/g==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/redux": {
@@ -7469,6 +7496,19 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -10452,6 +10492,15 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
@@ -12938,6 +12987,52 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-4.0.0.tgz",
@@ -13549,6 +13644,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-protobuf-schema": {
       "version": "2.1.0",
@@ -15312,6 +15412,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
@@ -15779,6 +15889,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-redux": "^7.2.2",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
@@ -52,6 +53,7 @@
   "devDependencies": {
     "@types/mapbox-gl": "^1.12.7",
     "@types/react-redux": "^7.1.11",
+    "@types/react-router-dom": "^5.1.6",
     "@types/redux": "^3.6.0",
     "@typescript-eslint/eslint-plugin": "^4.8.0",
     "@typescript-eslint/parser": "^4.8.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
+import { Route, Switch } from 'react-router-dom';
 import Main from './pages/Main';
+import Entry from './pages/Entry';
 
 /** 추후에 라우팅해야되면 수정할 예정 */
 function App(): React.ReactElement {
-  return <Main />;
+  return (
+    <Switch>
+      <Route path="/" exact component={Entry} />
+      <Route path="/map" component={Main} />
+    </Switch>
+  );
 }
 
 export default App;

--- a/src/components/Sidebar/SidebarContentMore/DetailType.tsx
+++ b/src/components/Sidebar/SidebarContentMore/DetailType.tsx
@@ -11,7 +11,6 @@ import Styler from './Styler';
 import {
   ElementNameType,
   SubElementNameType,
-  FeaturePropsType,
 } from '../../../store/common/type';
 
 interface PaddingProp {
@@ -65,7 +64,6 @@ const CheckRight = styled.div`
 function DetailType(): React.ReactElement {
   const {
     feature,
-    subFeature,
     element,
     subElement,
     sidebarTypeClickHandler,

--- a/src/components/Sidebar/SidebarContentMore/DetailType.tsx
+++ b/src/components/Sidebar/SidebarContentMore/DetailType.tsx
@@ -62,13 +62,12 @@ const CheckRight = styled.div`
   color: ${(props) => props.theme.GREEN};
 `;
 
-function DetailType({
-  feature,
-  subFeature,
-}: FeaturePropsType): React.ReactElement {
+function DetailType(): React.ReactElement {
   const {
-    sidebarTypeName,
-    sidebarSubTypeName,
+    feature,
+    subFeature,
+    element,
+    subElement,
     sidebarTypeClickHandler,
     sidebarSubTypeClickHandler,
   }: SidebarHookType = useSidebarType();
@@ -80,10 +79,6 @@ function DetailType({
   }: UseDetailHookType = useDetailType({
     sidebarTypeClickHandler,
     sidebarSubTypeClickHandler,
-    sidebarTypeName,
-    sidebarSubTypeName,
-    feature,
-    subFeature,
   });
 
   if (!feature) {
@@ -115,8 +110,8 @@ function DetailType({
             {section?.stroke.isChanged ? <Check>✓</Check> : <></>}
             <ListItem
               isSelected={
-                sidebarTypeName === ElementNameType.section &&
-                sidebarSubTypeName === SubElementNameType.stroke
+                element === ElementNameType.section &&
+                subElement === SubElementNameType.stroke
               }
               padding="second"
               clickHandler={() => {
@@ -193,12 +188,11 @@ function DetailType({
           )}
         </List>
       </DetailWrapper>
-      <Styler
-        feature={feature}
-        subFeature={subFeature}
-        element={sidebarTypeName as ElementNameType}
-        subElement={sidebarSubTypeName as SubElementNameType}
-      />
+      {element ? <Styler /> : <></>}
+      {/* // feature={feature}
+      // subFeature={subFeature}
+      // element={element as ElementNameType}
+      // subElement={subElement as SubElementNameType} */}
     </>
   );
 }

--- a/src/components/Sidebar/SidebarContentMore/FeatureType.tsx
+++ b/src/components/Sidebar/SidebarContentMore/FeatureType.tsx
@@ -6,7 +6,6 @@ import DetailType from './DetailType';
 import useSidebarType, {
   SidebarHookType,
 } from '../../../hooks/sidebar/useSidebarType';
-// import { FeatureNameType } from '../../../store/common/type';
 
 import FeatureTypeItem from './FeatureTypeItem';
 
@@ -30,7 +29,6 @@ const FeatureTypeTitle = styled.h2`
 function FeatureType(): React.ReactElement {
   const {
     feature,
-    // subFeature,
     sidebarTypeClickHandler,
     sidebarSubTypeClickHandler,
   }: SidebarHookType = useSidebarType();

--- a/src/components/Sidebar/SidebarContentMore/FeatureType.tsx
+++ b/src/components/Sidebar/SidebarContentMore/FeatureType.tsx
@@ -6,12 +6,12 @@ import DetailType from './DetailType';
 import useSidebarType, {
   SidebarHookType,
 } from '../../../hooks/sidebar/useSidebarType';
-import { FeatureNameType } from '../../../store/common/type';
+// import { FeatureNameType } from '../../../store/common/type';
 
 import FeatureTypeItem from './FeatureTypeItem';
 
 interface WrapperProps {
-  isFeatureName: string;
+  isFeatureName: string | null;
 }
 
 const FeatureTypeWrapper = styled.ul<WrapperProps>`
@@ -29,33 +29,28 @@ const FeatureTypeTitle = styled.h2`
 
 function FeatureType(): React.ReactElement {
   const {
+    feature,
+    // subFeature,
     sidebarTypeClickHandler,
     sidebarSubTypeClickHandler,
-    sidebarTypeName,
-    sidebarSubTypeName,
   }: SidebarHookType = useSidebarType();
 
   return (
     <>
-      <FeatureTypeWrapper isFeatureName={sidebarTypeName}>
+      <FeatureTypeWrapper isFeatureName={feature}>
         <FeatureTypeTitle>기능 유형</FeatureTypeTitle>
-        {data.map(({ typeKey, typeName, features }) => (
+        {data.map(({ typeKey, typeName, subFeatures }) => (
           <FeatureTypeItem
             key={typeKey}
             typeKey={typeKey}
             typeName={typeName}
-            features={features}
-            sidebarTypeName={sidebarTypeName}
-            sidebarSubTypeName={sidebarSubTypeName}
+            subFeatures={subFeatures}
             sidebarTypeClickHandler={sidebarTypeClickHandler}
             sidebarSubTypeClickHandler={sidebarSubTypeClickHandler}
           />
         ))}
       </FeatureTypeWrapper>
-      <DetailType
-        feature={sidebarTypeName as FeatureNameType}
-        subFeature={sidebarSubTypeName}
-      />
+      <DetailType />
     </>
   );
 }

--- a/src/components/Sidebar/SidebarContentMore/FeatureTypeItem.tsx
+++ b/src/components/Sidebar/SidebarContentMore/FeatureTypeItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '../../../utils/styles/styled';
 import { FeaturesType } from '../../../utils/rendering-data/featureTypeData';
-import { FeatureNameType } from '../../../store/common/type';
+import { FeatureNameType, FeatureState } from '../../../store/common/type';
 import useFeatureTypeItemHook from '../../../hooks/sidebar/useFeatureTypeItem';
 
 interface ListProps {
@@ -60,9 +60,9 @@ const Pointer = styled.span`
 interface FeatureTypeItemProps {
   typeKey: FeatureNameType;
   typeName: string;
-  features: FeaturesType[];
-  sidebarTypeName: string;
-  sidebarSubTypeName: string;
+  subFeatures: FeaturesType[];
+  // sidebarTypeName: string;
+  // sidebarSubTypeName: string;
   sidebarTypeClickHandler: (name: string) => void;
   sidebarSubTypeClickHandler: (name: string) => void;
 }
@@ -70,18 +70,20 @@ interface FeatureTypeItemProps {
 function FeatureTypeItem({
   typeKey,
   typeName,
-  features,
-  sidebarTypeName,
-  sidebarSubTypeName,
+  subFeatures,
+  // sidebarTypeName,
+  // sidebarSubTypeName,
   sidebarTypeClickHandler,
   sidebarSubTypeClickHandler,
 }: FeatureTypeItemProps): React.ReactElement {
-  const { featureList } = useFeatureTypeItemHook({ featureName: typeKey });
+  const { featureList, feature, subFeature } = useFeatureTypeItemHook({
+    featureName: typeKey,
+  });
 
   return (
     <>
       <FeatureList
-        isChecked={sidebarTypeName === typeKey && sidebarSubTypeName === 'all'}
+        isChecked={feature === typeKey && subFeature === 'all'}
         onClick={() => {
           sidebarTypeClickHandler(typeKey);
           sidebarSubTypeClickHandler('all');
@@ -91,10 +93,10 @@ function FeatureTypeItem({
         {typeName}
         <Pointer>{'>'}</Pointer>
       </FeatureList>
-      {features?.map(({ key, name }) => (
+      {subFeatures.map(({ key, name }) => (
         <SectionList
           key={key}
-          isChecked={sidebarSubTypeName === key}
+          isChecked={subFeature === key}
           onClick={() => {
             sidebarTypeClickHandler(typeKey);
             sidebarSubTypeClickHandler(key);

--- a/src/components/Sidebar/SidebarContentMore/FeatureTypeItem.tsx
+++ b/src/components/Sidebar/SidebarContentMore/FeatureTypeItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '../../../utils/styles/styled';
 import { FeaturesType } from '../../../utils/rendering-data/featureTypeData';
-import { FeatureNameType, FeatureState } from '../../../store/common/type';
+import { FeatureNameType, ElementNameType } from '../../../store/common/type';
 import useFeatureTypeItemHook from '../../../hooks/sidebar/useFeatureTypeItem';
 
 interface ListProps {
@@ -61,9 +61,7 @@ interface FeatureTypeItemProps {
   typeKey: FeatureNameType;
   typeName: string;
   subFeatures: FeaturesType[];
-  // sidebarTypeName: string;
-  // sidebarSubTypeName: string;
-  sidebarTypeClickHandler: (name: string) => void;
+  sidebarTypeClickHandler: (name: FeatureNameType | ElementNameType) => void;
   sidebarSubTypeClickHandler: (name: string) => void;
 }
 
@@ -71,8 +69,6 @@ function FeatureTypeItem({
   typeKey,
   typeName,
   subFeatures,
-  // sidebarTypeName,
-  // sidebarSubTypeName,
   sidebarTypeClickHandler,
   sidebarSubTypeClickHandler,
 }: FeatureTypeItemProps): React.ReactElement {

--- a/src/components/Sidebar/SidebarContentMore/Styler.tsx
+++ b/src/components/Sidebar/SidebarContentMore/Styler.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '../../../utils/styles/styled';
-// import { ElementPropsType } from '../../../store/common/type';
 import useStyleType, {
   UseStyleHookType,
 } from '../../../hooks/sidebar/useStyleType';

--- a/src/components/Sidebar/SidebarContentMore/Styler.tsx
+++ b/src/components/Sidebar/SidebarContentMore/Styler.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from '../../../utils/styles/styled';
-import { ElementPropsType } from '../../../store/common/type';
+// import { ElementPropsType } from '../../../store/common/type';
 import useStyleType, {
   UseStyleHookType,
 } from '../../../hooks/sidebar/useStyleType';
@@ -35,21 +35,12 @@ const Hr = styled.hr`
   color: ${(props) => props.theme.GREY};
 `;
 
-function Styler({
-  feature,
-  subFeature,
-  element,
-  subElement,
-}: ElementPropsType): React.ReactElement {
+function Styler(): React.ReactElement {
   const {
     styleElement: { visibility, color, weight, saturation, lightness },
     onStyleChange,
-  }: UseStyleHookType = useStyleType({
-    feature,
-    subFeature,
     element,
-    subElement,
-  });
+  }: UseStyleHookType = useStyleType();
 
   if (!element) {
     return <></>;

--- a/src/hooks/sidebar/useDetailType.ts
+++ b/src/hooks/sidebar/useDetailType.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import {
+  FeatureNameType,
   ElementNameType,
   SubElementNameType,
   FeatureType,
@@ -8,7 +9,7 @@ import {
 } from '../../store/common/type';
 
 interface UseDetailTypeProps {
-  sidebarTypeClickHandler: (name: string) => void;
+  sidebarTypeClickHandler: (name: FeatureNameType | ElementNameType) => void;
   sidebarSubTypeClickHandler: (name: string) => void;
 }
 

--- a/src/hooks/sidebar/useDetailType.ts
+++ b/src/hooks/sidebar/useDetailType.ts
@@ -1,17 +1,13 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import {
-  FeatureNameType,
   ElementNameType,
   SubElementNameType,
   FeatureType,
+  PayloadPropsType,
 } from '../../store/common/type';
 
 interface UseDetailTypeProps {
-  feature: FeatureNameType;
-  subFeature: string;
-  sidebarTypeName: string;
-  sidebarSubTypeName: string;
   sidebarTypeClickHandler: (name: string) => void;
   sidebarSubTypeClickHandler: (name: string) => void;
 }
@@ -34,15 +30,15 @@ const dummyDetail = {
 };
 
 function useDetailType({
-  feature,
-  subFeature,
-  sidebarTypeName,
-  sidebarSubTypeName,
   sidebarTypeClickHandler,
   sidebarSubTypeClickHandler,
 }: UseDetailTypeProps): UseDetailHookType {
+  const { feature, subFeature, element, subElement } = useSelector<RootState>(
+    (state) => state.sidebar
+  ) as PayloadPropsType;
+
   const detail = useSelector<RootState>((state) => {
-    if (!feature) {
+    if (!feature || !subFeature) {
       return dummyDetail;
     }
 
@@ -50,19 +46,19 @@ function useDetailType({
   }) as FeatureType;
 
   const styleClickHandler = (
-    element: ElementNameType,
-    subElement?: SubElementNameType
+    elementName: ElementNameType,
+    subElementName?: SubElementNameType
   ) => {
-    sidebarTypeClickHandler(element);
-    if (subElement) sidebarSubTypeClickHandler(subElement);
+    sidebarTypeClickHandler(elementName);
+    if (subElementName) sidebarSubTypeClickHandler(subElementName);
   };
 
   const checkIsSelected = (
-    element: ElementNameType,
-    subElement?: SubElementNameType
+    elementName: ElementNameType,
+    subElementName?: SubElementNameType
   ) => {
-    if (!subElement) return sidebarTypeName === element;
-    return sidebarTypeName === element && sidebarSubTypeName === subElement;
+    if (!subElementName) return elementName === element;
+    return elementName === element && subElementName === subElement;
   };
 
   return {

--- a/src/hooks/sidebar/useFeatureTypeItem.ts
+++ b/src/hooks/sidebar/useFeatureTypeItem.ts
@@ -1,9 +1,15 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
-import { FeatureState, FeatureNameType } from '../../store/common/type';
+import {
+  FeatureState,
+  FeatureNameType,
+  PayloadPropsType,
+} from '../../store/common/type';
 
 interface useFeatureTypeItemType {
   featureList: FeatureState;
+  feature: FeatureNameType | null;
+  subFeature: string | null;
 }
 
 export interface useFeatureTypeItemProps {
@@ -13,12 +19,17 @@ export interface useFeatureTypeItemProps {
 function useFeatureTypeItem({
   featureName,
 }: useFeatureTypeItemProps): useFeatureTypeItemType {
+  const { feature, subFeature } = useSelector<RootState>(
+    (state) => state.sidebar
+  ) as PayloadPropsType;
   const featureList = useSelector<RootState>(
     (state) => state[featureName]
   ) as FeatureState;
 
   return {
     featureList,
+    feature,
+    subFeature,
   };
 }
 

--- a/src/hooks/sidebar/useSidebarType.ts
+++ b/src/hooks/sidebar/useSidebarType.ts
@@ -1,63 +1,81 @@
-import { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
-  setFeature,
-  setSubFeature,
-  setElement,
-  setSubElement,
+  setSidebarProperties,
+  initSidebarProperties,
 } from '../../store/sidebar/action';
+import { RootState } from '../../store/index';
 import {
   FeatureNameType,
   ElementNameType,
   SubElementNameType,
+  PayloadPropsType,
 } from '../../store/common/type';
 
 export interface SidebarHookType {
   sidebarTypeClickHandler: (name: string) => void;
   sidebarSubTypeClickHandler: (name: string) => void;
-  sidebarTypeName: string;
-  sidebarSubTypeName: string;
+  feature: FeatureNameType | null;
+  subFeature: string | null;
+  element: ElementNameType | null;
+  subElement: SubElementNameType | null;
 }
 
 function useSidebarType(): SidebarHookType {
-  const [sidebarTypeName, setSidebarTypeName] = useState<string>('');
-  const [sidebarSubTypeName, setSidebarSubTypeName] = useState<string>('');
   const dispatch = useDispatch();
+  const sidebarStates = useSelector<RootState>(
+    (state) => state.sidebar
+  ) as PayloadPropsType;
+  const { feature, subFeature, element, subElement } = sidebarStates;
 
   const sidebarTypeClickHandler = (name: string) => {
-    if (name !== sidebarTypeName) {
-      if (
-        name === ElementNameType.section ||
-        name === ElementNameType.labelText ||
-        name === ElementNameType.labelIcon
-      ) {
-        dispatch(setElement(name as ElementNameType));
-      } else {
-        dispatch(setFeature(name as FeatureNameType));
-      }
-      setSidebarTypeName(name);
+    if ([feature, element].includes(name as any)) return;
+    if (Object.keys(ElementNameType).includes(name)) {
+      dispatch(
+        setSidebarProperties({
+          ...sidebarStates,
+          element: name as ElementNameType,
+          key: 'element',
+        })
+      );
+    } else {
+      dispatch(
+        initSidebarProperties({
+          ...sidebarStates,
+          feature: name as FeatureNameType,
+          key: 'feature',
+        })
+      );
     }
   };
 
   const sidebarSubTypeClickHandler = (name: string) => {
-    if (name !== sidebarSubTypeName) {
-      if (
-        name === SubElementNameType.fill ||
-        name === SubElementNameType.stroke
-      ) {
-        dispatch(setSubElement(name));
-      } else {
-        dispatch(setSubFeature(name));
-      }
-      setSidebarSubTypeName(name);
+    if ([subFeature, subElement].includes(name)) return;
+    if (Object.keys(SubElementNameType).includes(name)) {
+      dispatch(
+        setSidebarProperties({
+          ...sidebarStates,
+          subElement: name as SubElementNameType,
+          key: 'subElement',
+        })
+      );
+    } else {
+      dispatch(
+        setSidebarProperties({
+          ...sidebarStates,
+          subFeature: name,
+          key: 'subFeature',
+        })
+      );
     }
   };
 
   return {
     sidebarTypeClickHandler,
     sidebarSubTypeClickHandler,
-    sidebarTypeName,
-    sidebarSubTypeName,
+    feature,
+    subFeature,
+    element,
+    subElement,
   };
 }
 

--- a/src/hooks/sidebar/useSidebarType.ts
+++ b/src/hooks/sidebar/useSidebarType.ts
@@ -12,7 +12,7 @@ import {
 } from '../../store/common/type';
 
 export interface SidebarHookType {
-  sidebarTypeClickHandler: (name: string) => void;
+  sidebarTypeClickHandler: (name: FeatureNameType | ElementNameType) => void;
   sidebarSubTypeClickHandler: (name: string) => void;
   feature: FeatureNameType | null;
   subFeature: string | null;
@@ -27,8 +27,8 @@ function useSidebarType(): SidebarHookType {
   ) as PayloadPropsType;
   const { feature, subFeature, element, subElement } = sidebarStates;
 
-  const sidebarTypeClickHandler = (name: string) => {
-    if ([feature, element].includes(name as any)) return;
+  const sidebarTypeClickHandler = (name: FeatureNameType | ElementNameType) => {
+    if ([feature, element].includes(name)) return;
     if (Object.keys(ElementNameType).includes(name)) {
       dispatch(
         setSidebarProperties({

--- a/src/hooks/sidebar/useSidebarType.ts
+++ b/src/hooks/sidebar/useSidebarType.ts
@@ -9,6 +9,7 @@ import {
   ElementNameType,
   SubElementNameType,
   PayloadPropsType,
+  SidebarProperties,
 } from '../../store/common/type';
 
 export interface SidebarHookType {
@@ -34,7 +35,7 @@ function useSidebarType(): SidebarHookType {
         setSidebarProperties({
           ...sidebarStates,
           element: name as ElementNameType,
-          key: 'element',
+          key: SidebarProperties.element,
         })
       );
     } else {
@@ -42,20 +43,19 @@ function useSidebarType(): SidebarHookType {
         initSidebarProperties({
           ...sidebarStates,
           feature: name as FeatureNameType,
-          key: 'feature',
+          key: SidebarProperties.feature,
         })
       );
     }
   };
 
   const sidebarSubTypeClickHandler = (name: string) => {
-    if ([subFeature, subElement].includes(name)) return;
     if (Object.keys(SubElementNameType).includes(name)) {
       dispatch(
         setSidebarProperties({
           ...sidebarStates,
           subElement: name as SubElementNameType,
-          key: 'subElement',
+          key: SidebarProperties.subElement,
         })
       );
     } else {
@@ -63,7 +63,7 @@ function useSidebarType(): SidebarHookType {
         setSidebarProperties({
           ...sidebarStates,
           subFeature: name,
-          key: 'subFeature',
+          key: SidebarProperties.subFeature,
         })
       );
     }

--- a/src/hooks/sidebar/useStyleType.ts
+++ b/src/hooks/sidebar/useStyleType.ts
@@ -8,6 +8,8 @@ import {
   ElementNameType,
   SubElementNameType,
   ElementPropsType,
+  PayloadPropsType,
+  FeatureNameType,
 } from '../../store/common/type';
 import { setStyle } from '../../store/style/action';
 import { getDefaultStyle } from '../../store/style/properties';
@@ -16,26 +18,34 @@ import * as mapStyling from '../../utils/map-styling';
 export interface UseStyleHookType {
   styleElement: StyleType;
   onStyleChange: (key: StyleKeyType, value: string | number) => void;
+  element: ElementNameType | null;
 }
 
-function useStyleType({
-  feature,
-  subFeature,
-  element,
-  subElement,
-}: ElementPropsType): UseStyleHookType {
+function useStyleType(): UseStyleHookType {
+  //   {
+  //   feature,
+  //   subFeature,
+  //   element,
+  //   subElement,
+  // }: ElementPropsType
   const dispatch = useDispatch();
 
+  const { feature, subFeature, element, subElement } = useSelector<RootState>(
+    (state) => state.sidebar
+  ) as PayloadPropsType;
   const map = useSelector<RootState>((state) => state.map.map) as mapboxgl.Map;
   const styleElement = useSelector<RootState>((state) => {
-    if (!element) {
+    if (!feature || !subFeature || !element) {
+      // ?!?
       return getDefaultStyle({
         feature,
         subFeature,
         element,
         subElement,
-      });
+      } as ElementPropsType);
     }
+    // if (!feature || !subFeature || !element) return null;
+    console.log(state, feature, subFeature);
     const newFeature = state[feature][subFeature];
     if (element === ElementNameType.labelIcon) return newFeature[element];
     return newFeature[element][subElement as SubElementNameType];
@@ -43,6 +53,8 @@ function useStyleType({
 
   const onStyleChange = useCallback(
     (key: StyleKeyType, value: string | number) => {
+      if (!feature || !subFeature || !element || !subElement) return;
+
       mapStyling[feature]({
         map,
         subFeature,
@@ -74,6 +86,7 @@ function useStyleType({
   return {
     styleElement,
     onStyleChange,
+    element,
   };
 }
 

--- a/src/hooks/sidebar/useStyleType.ts
+++ b/src/hooks/sidebar/useStyleType.ts
@@ -7,12 +7,9 @@ import {
   StyleKeyType,
   ElementNameType,
   SubElementNameType,
-  ElementPropsType,
   PayloadPropsType,
-  FeatureNameType,
 } from '../../store/common/type';
 import { setStyle } from '../../store/style/action';
-import { getDefaultStyle } from '../../store/style/properties';
 import * as mapStyling from '../../utils/map-styling';
 
 export interface UseStyleHookType {
@@ -22,12 +19,6 @@ export interface UseStyleHookType {
 }
 
 function useStyleType(): UseStyleHookType {
-  //   {
-  //   feature,
-  //   subFeature,
-  //   element,
-  //   subElement,
-  // }: ElementPropsType
   const dispatch = useDispatch();
 
   const { feature, subFeature, element, subElement } = useSelector<RootState>(
@@ -36,16 +27,9 @@ function useStyleType(): UseStyleHookType {
   const map = useSelector<RootState>((state) => state.map.map) as mapboxgl.Map;
   const styleElement = useSelector<RootState>((state) => {
     if (!feature || !subFeature || !element) {
-      // ?!?
-      return getDefaultStyle({
-        feature,
-        subFeature,
-        element,
-        subElement,
-      } as ElementPropsType);
+      return null;
     }
-    // if (!feature || !subFeature || !element) return null;
-    console.log(state, feature, subFeature);
+
     const newFeature = state[feature][subFeature];
     if (element === ElementNameType.labelIcon) return newFeature[element];
     return newFeature[element][subElement as SubElementNameType];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from 'emotion-theming';
 import App from './App';
 
@@ -11,12 +12,14 @@ import store from './store';
 
 ReactDOM.render(
   <React.StrictMode>
-    <Provider store={store}>
-      <ThemeProvider theme={theme}>
-        <GlobalStyle />
-        <App />
-      </ThemeProvider>
-    </Provider>
+    <BrowserRouter>
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <GlobalStyle />
+          <App />
+        </ThemeProvider>
+      </Provider>
+    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/pages/Entry.tsx
+++ b/src/pages/Entry.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Canvas from '../components/Canvas';
 import styled from '../utils/styles/styled';
 
@@ -44,7 +45,9 @@ function Entry(): React.ReactElement {
     <BackGround>
       <Container>
         <Canvas />
-        <StartButton>시작하기</StartButton>
+        <StartButton>
+          <Link to="/map">시작하기</Link>
+        </StartButton>
       </Container>
     </BackGround>
   );

--- a/src/store/common/type.ts
+++ b/src/store/common/type.ts
@@ -1,10 +1,5 @@
 import { init, setStyle } from '../style/action';
-import {
-  setFeature,
-  setSubFeature,
-  setElement,
-  setSubElement,
-} from '../sidebar/action';
+import { setSidebarProperties, initSidebarProperties } from '../sidebar/action';
 
 export type hello = 'landmark';
 
@@ -77,13 +72,18 @@ export interface ElementPropsType extends FeaturePropsType {
 
 export type ActionType = ReturnType<typeof init> | ReturnType<typeof setStyle>;
 export type SidebarActionType =
-  | ReturnType<typeof setFeature>
-  | ReturnType<typeof setSubFeature>
-  | ReturnType<typeof setElement>
-  | ReturnType<typeof setSubElement>;
-
+  | ReturnType<typeof setSidebarProperties>
+  | ReturnType<typeof initSidebarProperties>;
 export interface ActionPayload extends ElementPropsType {
   style: StyleType;
+}
+
+export interface PayloadPropsType {
+  key: 'feature' | 'subFeature' | 'element' | 'subElement';
+  feature: FeatureNameType | null;
+  subFeature: string | null;
+  element: ElementNameType | null;
+  subElement: SubElementNameType | null;
 }
 
 export interface StylePropsType {

--- a/src/store/common/type.ts
+++ b/src/store/common/type.ts
@@ -33,6 +33,13 @@ export enum FeatureNameType {
   marker = 'marker',
 }
 
+export enum SidebarProperties {
+  feature = 'feature',
+  subFeature = 'subFeature',
+  element = 'element',
+  subElement = 'subElement',
+}
+
 export interface objType {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [name: string]: any;

--- a/src/store/sidebar/action.ts
+++ b/src/store/sidebar/action.ts
@@ -1,46 +1,31 @@
-import {
-  FeatureNameType,
-  ElementNameType,
-  SubElementNameType,
-} from '../common/type';
+import { PayloadPropsType } from '../common/type';
 
-export const SET_FEATURE = 'SET_FEATURE' as const;
-export const SET_SUBFEATURE = 'SET_SUBFEATURE' as const;
-export const SET_ELEMENT = 'SET_ELEMENT' as const;
-export const SET_SUBELEMENT = 'SET_SUBELEMENT' as const;
+export const SET_SIDEBAR_PROPERTIES = 'SET_SIDEBAR_PROPERTIES' as const;
+export const INIT_SIDEBAR_PROPERTIES = 'INIT_SIDEBAR_PROPERTIES' as const;
 
 export interface SidebarActionType {
-  type:
-    | typeof SET_FEATURE
-    | typeof SET_SUBFEATURE
-    | typeof SET_ELEMENT
-    | typeof SET_SUBELEMENT;
-  payload: {
-    feature?: FeatureNameType;
-    subFeature?: string;
-    element?: ElementNameType;
-    subElement?: SubElementNameType;
-  };
+  type: typeof SET_SIDEBAR_PROPERTIES | typeof INIT_SIDEBAR_PROPERTIES;
+  payload: PayloadPropsType;
 }
 
-export const setFeature = (feature: FeatureNameType): SidebarActionType => ({
-  type: SET_FEATURE,
-  payload: { feature },
+export const setSidebarProperties = ({
+  key,
+  feature,
+  subFeature,
+  element,
+  subElement,
+}: PayloadPropsType): SidebarActionType => ({
+  type: SET_SIDEBAR_PROPERTIES,
+  payload: { key, feature, subFeature, element, subElement },
 });
 
-export const setSubFeature = (subFeature: string): SidebarActionType => ({
-  type: SET_SUBFEATURE,
-  payload: { subFeature },
-});
-
-export const setElement = (element: ElementNameType): SidebarActionType => ({
-  type: SET_ELEMENT,
-  payload: { element },
-});
-
-export const setSubElement = (
-  subElement: SubElementNameType
-): SidebarActionType => ({
-  type: SET_SUBELEMENT,
-  payload: { subElement },
+export const initSidebarProperties = ({
+  key,
+  feature,
+  subFeature,
+  element,
+  subElement,
+}: PayloadPropsType): SidebarActionType => ({
+  type: INIT_SIDEBAR_PROPERTIES,
+  payload: { key, feature, subFeature, element, subElement },
 });

--- a/src/store/sidebar/reducer.ts
+++ b/src/store/sidebar/reducer.ts
@@ -1,58 +1,29 @@
-import {
-  FeatureNameType,
-  ElementNameType,
-  SubElementNameType,
-  SidebarActionType,
-} from '../common/type';
-import {
-  SET_FEATURE,
-  SET_SUBFEATURE,
-  SET_ELEMENT,
-  SET_SUBELEMENT,
-} from './action';
+import { PayloadPropsType, SidebarActionType } from '../common/type';
+import { SET_SIDEBAR_PROPERTIES, INIT_SIDEBAR_PROPERTIES } from './action';
 
-interface SidebarStateType {
-  feature?: FeatureNameType | '';
-  subFeature?: string;
-  element?: ElementNameType | '';
-  subElement?: SubElementNameType | '';
-}
-
-const initialState: SidebarStateType = {
-  feature: '',
-  subFeature: '',
-  element: '',
-  subElement: '',
+const initialState: PayloadPropsType = {
+  key: 'feature',
+  feature: null,
+  subFeature: null,
+  element: null,
+  subElement: null,
 };
 
 function sidebarReducer(
-  state: SidebarStateType = initialState,
+  state: PayloadPropsType = initialState,
   action: SidebarActionType
-): SidebarStateType {
+): PayloadPropsType {
   switch (action.type) {
-    case SET_FEATURE: {
+    case SET_SIDEBAR_PROPERTIES: {
       return {
         ...state,
-        feature: action.payload.feature,
+        [action.payload.key]: action.payload[action.payload.key],
       };
     }
-    case SET_SUBFEATURE: {
+    case INIT_SIDEBAR_PROPERTIES: {
       return {
-        ...state,
-        subFeature: action.payload.subFeature,
-      };
-    }
-    case SET_ELEMENT: {
-      return {
-        ...state,
-        element: action.payload.element,
-      };
-    }
-    case SET_SUBELEMENT: {
-      return {
-        ...state,
-
-        subElement: action.payload.subElement,
+        ...initialState,
+        [action.payload.key]: action.payload[action.payload.key],
       };
     }
     default:

--- a/src/store/style/getReducer.ts
+++ b/src/store/style/getReducer.ts
@@ -20,7 +20,7 @@ interface ReducerType {
 export default function getReducer(IDX: number): ReducerType {
   const subFeatures = [
     'all',
-    ...(renderingData[IDX].features?.map((v) => v.key) as string[]),
+    ...(renderingData[IDX].subFeatures?.map((v) => v.key) as string[]),
   ];
 
   const initialState = subFeatures.reduce((acc: FeatureState, cur: string) => {

--- a/src/utils/rendering-data/featureTypeData.ts
+++ b/src/utils/rendering-data/featureTypeData.ts
@@ -7,14 +7,14 @@ export interface FeaturesType {
 export interface DataType {
   typeKey: FeatureNameType;
   typeName: string;
-  features: FeaturesType[];
+  subFeatures: FeaturesType[];
 }
 
 const data: DataType[] = [
   {
     typeKey: FeatureNameType.poi,
     typeName: 'POI',
-    features: [
+    subFeatures: [
       { key: 'landmark', name: '랜드마크' },
       { key: 'business', name: '상업시설' },
       { key: 'government', name: '공공시설' },
@@ -29,7 +29,7 @@ const data: DataType[] = [
   {
     typeKey: FeatureNameType.road,
     typeName: '도로',
-    features: [
+    subFeatures: [
       { key: 'arterial', name: '주요도로' },
       { key: 'local', name: '일반도로' },
       { key: 'sidewalk', name: '인도' },
@@ -38,7 +38,7 @@ const data: DataType[] = [
   {
     typeKey: FeatureNameType.administrative,
     typeName: '행정구역',
-    features: [
+    subFeatures: [
       { key: 'country', name: '국가' },
       { key: 'state', name: '도/주' },
       { key: 'locality', name: '그외' },
@@ -47,7 +47,7 @@ const data: DataType[] = [
   {
     typeKey: FeatureNameType.landscape,
     typeName: '경관',
-    features: [
+    subFeatures: [
       { key: 'human-made', name: '인공물' },
       { key: 'building', name: '건물' },
       { key: 'natural', name: '자연물' },
@@ -58,15 +58,15 @@ const data: DataType[] = [
   {
     typeKey: FeatureNameType.transit,
     typeName: '교통',
-    features: [
+    subFeatures: [
       { key: 'airport', name: '공항' },
       { key: 'bus', name: '버스' },
       { key: 'rail', name: '철도' },
       { key: 'subway', name: '지하철' },
     ],
   },
-  { typeKey: FeatureNameType.water, typeName: '물', features: [] },
-  { typeKey: FeatureNameType.marker, typeName: '마크', features: [] },
+  { typeKey: FeatureNameType.water, typeName: '물', subFeatures: [] },
+  { typeKey: FeatureNameType.marker, typeName: '마크', subFeatures: [] },
 ];
 
 export default data;


### PR DESCRIPTION
## 상세사항
- 현재 선택한 사이드바의 항목을 상태로 분리하였습니다.
- 따라서 기존에 feature, detail 컴포넌트가 가지고 있던 상태가 사라지게 되고, 스토어에서 받아서 사용하게 됩니다.
- poi - icon 에서 road로 이동시 발생하는 에러를 해결하였습니다.
- 하지만 아래 사진과 같은 이슈가 있습니다.(한번 더 클릭하면 해결됩니다) > 해결하였습니다
![스크린샷 2020-12-03 오후 9 43 16](https://user-images.githubusercontent.com/26402298/101020017-30414700-35b1-11eb-9a0f-877704c88fe7.png)
- 20시에 종료 후 따로 타입정의와 불필요한 로직을 제거하였으니 확인부탁드립니다

## 기타사항
- 내일 데모를 위해서 react-router를 사용해서 메인 화면을 붙여놓겠습니다! > 붙였습니다
