### PR TITLE
새로고침 후 마지막 지도 스타일 유지 / undo, redo 구현

### DIFF
--- a/src/components/Icon/RedoIcon.tsx
+++ b/src/components/Icon/RedoIcon.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 interface RedoIconProps {
   className?: string;
+  onClick: () => void;
 }
 
-function RedoIcon({ className }: RedoIconProps): React.ReactElement {
+function RedoIcon({ className, onClick }: RedoIconProps): React.ReactElement {
   return (
     <svg
+      onClick={onClick}
       className={className}
       xmlns="http://www.w3.org/2000/svg"
       height="24"

--- a/src/components/Icon/UndoIcon.tsx
+++ b/src/components/Icon/UndoIcon.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 interface UndoIconProps {
   className?: string;
+  onClick: () => void;
 }
 
-function UndoIcon({ className }: UndoIconProps): React.ReactElement {
+function UndoIcon({ className, onClick }: UndoIconProps): React.ReactElement {
   return (
     <svg
+      onClick={onClick}
       className={className}
       xmlns="http://www.w3.org/2000/svg"
       height="24"

--- a/src/components/Map/History/History.tsx
+++ b/src/components/Map/History/History.tsx
@@ -1,10 +1,8 @@
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import styled from '../../../utils/styles/styled';
 import { RootState } from '../../../store/index';
-import useHistoryFeature from '../../../hooks/map/useHistoryFeature';
 import { HistoryPropsType } from '../../../store/common/type';
-
 import { comparisonButtonClickHandlerType } from '../../../hooks/map/useCompareFeature';
 
 const HistoryWapper = styled.div`
@@ -50,11 +48,6 @@ function History({
   isHistoryOpen,
   comparisonButtonClickHandler,
 }: HistoryProps): ReactElement {
-  const { initHistoryStatus } = useHistoryFeature();
-  useEffect(() => {
-    initHistoryStatus();
-  }, []);
-
   const { log } = useSelector<RootState>(
     (state) => state.history
   ) as HistoryPropsType;
@@ -65,14 +58,17 @@ function History({
     <HistoryWapper>
       <HistoryTitle text-align="center">HISTORY LIST</HistoryTitle>
       {log ? (
-        log.map((item) => (
-          <HistoryItem
-            key={item.id}
-            onClick={() => comparisonButtonClickHandler(/** props */)}
-          >
-            {item.display}
-          </HistoryItem>
-        ))
+        log
+          .map((item) => (
+            <HistoryItem
+              key={item.id}
+              onClick={() => comparisonButtonClickHandler(/** props */)}
+            >
+              <p>{`${item.feature} > ${item.subFeature} > ${item.element} > ${item.subElement}`}</p>
+              <p>{`${item.changedKey}가 ${item.changedValue}로 변경`}</p>
+            </HistoryItem>
+          ))
+          .reverse()
       ) : (
         <></>
       )}

--- a/src/components/Sidebar/SidebarContentMore/DetailTypeSubList.tsx
+++ b/src/components/Sidebar/SidebarContentMore/DetailTypeSubList.tsx
@@ -59,7 +59,7 @@ function DetailTypeSubList({
 }: PropsType): React.ReactElement {
   const childComponent = childrenProps.map((child: ChildrenType) => {
     return child.childrenProps.length !== 0 ? (
-      <div key={child.title}>
+      <div key={`${child.title}`}>
         <Text padding="second">{child.title}</Text>
         {child.childrenProps.map((innerChild: ChildrenType) => {
           return (

--- a/src/components/Sidebar/SidebarHeader/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader/SidebarHeader.tsx
@@ -3,6 +3,7 @@ import styled from '../../../utils/styles/styled';
 import useSidebarHeader, {
   useSidebarHeaderType,
 } from '../../../hooks/sidebar/useSidebarHeader';
+import useUndoRedo from '../../../hooks/sidebar/useUndoRedo';
 
 import UndoIcon from '../../Icon/UndoIcon';
 import RedoIcon from '../../Icon/RedoIcon';
@@ -76,13 +77,14 @@ function SidebarHeader({
     isOpened,
     dropdownToggleHandler,
   }: useSidebarHeaderType = useSidebarHeader();
+  const { undoHandler, redoHandler } = useUndoRedo();
 
   return (
     <HeaderWrapper>
       <HeaderTitle>{isAdvanced ? '고급 설정' : '스타일 맵 만들기'}</HeaderTitle>
       <Btns>
-        <UndoBtn />
-        <RedoBtn />
+        <UndoBtn onClick={undoHandler} />
+        <RedoBtn onClick={redoHandler} />
         <DropdownBtn onClick={dropdownToggleHandler} />
         <SidebarDropdown
           isOpened={isOpened}

--- a/src/hooks/common/useWholeStyle.ts
+++ b/src/hooks/common/useWholeStyle.ts
@@ -1,11 +1,12 @@
 import mapboxgl from 'mapbox-gl';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../store';
-import { setWholeStyle } from '../../store/style/action';
+import { setWholeStyle, replaceWholeStyle } from '../../store/style/action';
 import {
   WholeStyleActionPayload,
   FeatureState,
   FeatureNameType,
+  StyleStoreType,
 } from '../../store/common/type';
 import { useEffect, useState } from 'react';
 import setFeatureStyle from '../../utils/setFeatureStyle';
@@ -13,9 +14,10 @@ import setFeatureStyle from '../../utils/setFeatureStyle';
 interface WholeStyleHook {
   flag: boolean;
   changeStyle: (inputStyle: WholeStyleActionPayload) => void;
+  replaceStyle: (inputStyle: StyleStoreType) => void;
 }
 
-type WholeStyleStoreType = {
+export type WholeStyleStoreType = {
   [featureName in FeatureNameType]: FeatureState;
 };
 
@@ -63,9 +65,15 @@ function useWholeStyle(): WholeStyleHook {
     setFlag(true);
   };
 
+  const replaceStyle = (inputStyle: StyleStoreType): void => {
+    dispatch(replaceWholeStyle(inputStyle));
+    setFlag(true);
+  };
+
   return {
     flag,
     changeStyle,
+    replaceStyle,
   };
 }
 

--- a/src/hooks/map/useMap.ts
+++ b/src/hooks/map/useMap.ts
@@ -1,10 +1,15 @@
-import { RefObject, useRef, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { RefObject, useRef, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { initMap } from '../../store/map/action';
 import useWholeStyle from '../../hooks/common/useWholeStyle';
 import { urlToJson } from '../../utils/urlParsing';
-import { WholeStyleActionPayload } from '../../store/common/type';
+import {
+  WholeStyleActionPayload,
+  HistoryPropsType,
+} from '../../store/common/type';
 import validateStyle from '../../utils/validateStyle';
+import { RootState } from '../../store/index';
+import useHistoryFeature from './useHistoryFeature';
 
 export interface MapHookType {
   containerRef: RefObject<HTMLDivElement>;
@@ -17,19 +22,34 @@ function useMap(): MapHookType {
   const containerRef = useRef<HTMLDivElement>(null);
   const afterMapRef = useRef<HTMLDivElement>(null);
   const beforeMapRef = useRef<HTMLDivElement>(null);
+  const { log, currentIdx } = useSelector<RootState>(
+    (state) => state.history
+  ) as HistoryPropsType;
 
-  const { changeStyle } = useWholeStyle();
-
+  const { changeStyle, replaceStyle } = useWholeStyle();
+  const { initHistoryStatus } = useHistoryFeature();
+  const [flag, setFlag] = useState(false);
   const { search, pathname } = window.location;
 
-  const initializeMap = () => {
+  const initializeMap = (): void => {
     if (search && pathname === '/show') {
       const states = urlToJson();
       if (validateStyle(states as WholeStyleActionPayload)) {
         changeStyle(states as WholeStyleActionPayload);
       }
+      return;
     }
+    initHistoryStatus();
+    setFlag(true);
   };
+
+  useEffect(() => {
+    if (flag && log && log.length) {
+      const { wholeStyle } = log[currentIdx as number];
+      if (wholeStyle) replaceStyle(wholeStyle);
+      setFlag(false);
+    }
+  }, [flag]);
 
   useEffect(() => {
     dispatch(initMap(afterMapRef, initializeMap));

--- a/src/hooks/sidebar/useSidebarFooter.ts
+++ b/src/hooks/sidebar/useSidebarFooter.ts
@@ -7,9 +7,8 @@ function useSidebarFooter() {
 
   const { exportStyle } = useExportStyle();
 
-  const data = exportStyle();
-
   const onClickExport = () => {
+    const data = exportStyle();
     setStyle(data);
     setIsOpen(true);
   };

--- a/src/hooks/sidebar/useStyleType.ts
+++ b/src/hooks/sidebar/useStyleType.ts
@@ -126,7 +126,7 @@ function useStyleType(): UseStyleHookType {
         feature,
         subFeature,
         element,
-        subElement,
+        subElement: subElement as SubElementNameType,
         style: {
           ...styleElement,
           [key]: value,

--- a/src/hooks/sidebar/useStyleType.ts
+++ b/src/hooks/sidebar/useStyleType.ts
@@ -1,6 +1,6 @@
 import mapboxgl from 'mapbox-gl';
 import { useSelector, useDispatch } from 'react-redux';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { RootState } from '../../store';
 import {
   StyleType,
@@ -73,11 +73,17 @@ const getNewColorStyle = (
   return newStyleObj;
 };
 
+interface changedObjType {
+  key?: StyleKeyType;
+  value?: string | number;
+}
+
 function useStyleType(): UseStyleHookType {
   const dispatch = useDispatch();
-
+  const [changedObj, setChangedObj] = useState<changedObjType>({});
   const { addHistory } = useHistoryFeature();
   const map = useSelector<RootState>((state) => state.map.map) as mapboxgl.Map;
+
   const {
     poi,
     landscape,
@@ -90,6 +96,7 @@ function useStyleType(): UseStyleHookType {
   const { feature, subFeature, element, subElement } = useSelector<RootState>(
     (state) => state.sidebar
   ) as PayloadPropsType;
+
   const styleElement = useSelector<RootState>((state) => {
     if (!feature || !subFeature || !element) {
       return null;
@@ -99,6 +106,37 @@ function useStyleType(): UseStyleHookType {
     if (element === ElementNameType.labelIcon) return newFeature[element];
     return newFeature[element][subElement as SubElementNameType];
   }) as StyleType;
+
+  useEffect(() => {
+    const { key, value } = changedObj;
+    if (key && value && feature && subFeature && element) {
+      const wholeStyle = {
+        poi,
+        landscape,
+        administrative,
+        road,
+        transit,
+        water,
+        marker,
+      };
+
+      addHistory({
+        changedKey: key,
+        changedValue: value,
+        feature,
+        subFeature,
+        element,
+        subElement,
+        style: {
+          ...styleElement,
+          [key]: value,
+        },
+        wholeStyle,
+      });
+
+      setChangedObj({});
+    }
+  }, [changedObj]);
 
   const onStyleChange = useCallback(
     (key: StyleKeyType, value: string | number) => {
@@ -132,35 +170,7 @@ function useStyleType(): UseStyleHookType {
           },
         })
       );
-
-      const wholeStyle = {
-        poi,
-        landscape,
-        administrative,
-        road,
-        transit,
-        water,
-        marker,
-      };
-      wholeStyle[feature][subFeature][element][
-        subElement as SubElementNameType
-      ] = {
-        ...styleElement,
-        ...newStyleObj,
-      };
-      addHistory({
-        changedKey: key,
-        value,
-        feature,
-        subFeature,
-        element,
-        subElement,
-        style: {
-          ...styleElement,
-          [key]: value,
-        },
-        wholeStyle,
-      });
+      setChangedObj({ key, value });
     },
     [feature, subFeature, element, subElement, styleElement]
   );

--- a/src/hooks/sidebar/useUndoRedo.ts
+++ b/src/hooks/sidebar/useUndoRedo.ts
@@ -1,0 +1,115 @@
+import mapboxgl from 'mapbox-gl';
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '../../store';
+import {
+  HistoryPropsType,
+  SubElementNameType,
+  StyleType,
+  SubElementType,
+} from '../../store/common/type';
+import { getDefaultStyle } from '../../store/style/properties';
+import { setCurrentIndex } from '../../store/history/action';
+import { setStyle } from '../../store/style/action';
+import * as mapStyling from '../../utils/map-styling';
+
+interface UseUndoRedoType {
+  undoHandler: () => void;
+  redoHandler: () => void;
+}
+
+function useUndoRedo(): UseUndoRedoType {
+  const dispatch = useDispatch();
+  const map = useSelector<RootState>((state) => state.map.map) as mapboxgl.Map;
+  const { log, currentIdx } = useSelector<RootState>(
+    (state) => state.history
+  ) as HistoryPropsType;
+
+  const undoHandler = () => {
+    if (!log || currentIdx === null || currentIdx < 0) return;
+    const undoIdx = currentIdx - 1;
+    const { feature, subFeature, element, subElement, style, changedKey } = log[
+      currentIdx
+    ];
+    if (!feature || !subFeature || !element) return;
+
+    dispatch(setCurrentIndex(undoIdx));
+    let beforeStyle;
+    if (currentIdx === 0) {
+      beforeStyle = subElement
+        ? getDefaultStyle({
+            feature,
+            subFeature,
+            element,
+            subElement,
+          })
+        : getDefaultStyle({ feature, subFeature, element });
+    } else {
+      const { wholeStyle } = log[undoIdx];
+      beforeStyle =
+        subElement && wholeStyle
+          ? (wholeStyle[feature][subFeature][element] as SubElementType)[
+              subElement
+            ]
+          : wholeStyle[feature][subFeature][element];
+    }
+
+    mapStyling[feature]({
+      map,
+      subFeature,
+      key: changedKey,
+      element,
+      subElement,
+      style: {
+        ...style,
+        [changedKey]: (beforeStyle as StyleType)[changedKey],
+      },
+    });
+
+    dispatch(
+      setStyle({
+        feature,
+        subFeature,
+        element,
+        subElement: subElement as SubElementNameType,
+        style: {
+          ...style,
+          [changedKey]: (beforeStyle as StyleType)[changedKey],
+        },
+      })
+    );
+  };
+
+  const redoHandler = () => {
+    if (!log || (log && currentIdx === log.length - 1)) return;
+    const redoIdx = (currentIdx as number) + 1;
+
+    const { feature, subFeature, element, subElement, style, changedKey } = log[
+      redoIdx as number
+    ];
+    if (!feature || !subFeature || !element) return;
+
+    dispatch(setCurrentIndex(redoIdx));
+
+    mapStyling[feature]({
+      map,
+      subFeature,
+      key: changedKey,
+      element,
+      subElement,
+      style,
+    });
+
+    dispatch(
+      setStyle({
+        feature,
+        subFeature,
+        element,
+        subElement: subElement as SubElementNameType,
+        style,
+      })
+    );
+  };
+
+  return { undoHandler, redoHandler };
+}
+export default useUndoRedo;

--- a/src/store/common/type.ts
+++ b/src/store/common/type.ts
@@ -1,4 +1,9 @@
-import { init, setStyle, setWholeStyle } from '../style/action';
+import {
+  init,
+  replaceWholeStyle,
+  setStyle,
+  setWholeStyle,
+} from '../style/action';
 import { setSidebarProperties, initSidebarProperties } from '../sidebar/action';
 import { INIT_HISTORY, ADD_LOG } from '../history/action';
 
@@ -155,22 +160,32 @@ export type SidebarActionType =
 export type ActionType =
   | ReturnType<typeof init>
   | ReturnType<typeof setStyle>
-  | ReturnType<typeof setWholeStyle>;
+  | ReturnType<typeof setWholeStyle>
+  | ReturnType<typeof replaceWholeStyle>;
 
-export interface HistoryPropsType {
-  log?: { id: string; display: string }[];
-}
+/** Style Store Type for Replace */
+export type StyleStoreType = {
+  [featureName in FeatureNameType]: FeatureState;
+};
 
+/** History Type */
 export interface HistoryInfoPropsType {
-  value: string | number;
+  id?: string;
+  changedValue: string | number;
   changedKey: StyleKeyType;
   feature: FeatureNameType | null;
   subFeature: string | null;
   element: ElementNameType | null;
   subElement: SubElementNameType | null;
   style: StyleType;
-  wholeStyle: PropertyType;
+  wholeStyle: StyleStoreType;
 }
+
+export interface HistoryPropsType {
+  log?: HistoryInfoPropsType[];
+  currentIdx: number | null;
+}
+
 export interface HistoryActionType {
   type: typeof INIT_HISTORY | typeof ADD_LOG;
   payload: null | {
@@ -179,7 +194,7 @@ export interface HistoryActionType {
     subFeature: string | null;
     element: ElementNameType | null;
     subElement: SubElementNameType | null;
-    wholeStyle: PropertyType;
+    wholeStyle: StyleStoreType;
   };
 }
 
@@ -195,6 +210,7 @@ export interface PayloadPropsType {
   subElement: SubElementNameType | null;
 }
 
+/** Whole Style Type for Set */
 export interface StyleActionPayload {
   isChanged?: boolean;
   visibility?: string;

--- a/src/store/common/type.ts
+++ b/src/store/common/type.ts
@@ -5,7 +5,7 @@ import {
   setWholeStyle,
 } from '../style/action';
 import { setSidebarProperties, initSidebarProperties } from '../sidebar/action';
-import { INIT_HISTORY, ADD_LOG } from '../history/action';
+import { INIT_HISTORY, ADD_LOG, SET_CURRENT_INDEX } from '../history/action';
 
 export type hello = 'landmark';
 
@@ -173,10 +173,10 @@ export interface HistoryInfoPropsType {
   id?: string;
   changedValue: string | number;
   changedKey: StyleKeyType;
-  feature: FeatureNameType | null;
-  subFeature: string | null;
-  element: ElementNameType | null;
-  subElement: SubElementNameType | null;
+  feature: FeatureNameType;
+  subFeature: string;
+  element: ElementNameType;
+  subElement: SubElementNameType;
   style: StyleType;
   wholeStyle: StyleStoreType;
 }
@@ -186,16 +186,23 @@ export interface HistoryPropsType {
   currentIdx: number | null;
 }
 
+export interface SetIndexPayload {
+  currentIndex: number;
+}
+
 export interface HistoryActionType {
-  type: typeof INIT_HISTORY | typeof ADD_LOG;
-  payload: null | {
-    changedKey: StyleKeyType;
-    feature: FeatureNameType | null;
-    subFeature: string | null;
-    element: ElementNameType | null;
-    subElement: SubElementNameType | null;
-    wholeStyle: StyleStoreType;
-  };
+  type: typeof INIT_HISTORY | typeof ADD_LOG | typeof SET_CURRENT_INDEX;
+  payload:
+    | null
+    | SetIndexPayload
+    | {
+        changedKey: StyleKeyType;
+        feature: FeatureNameType;
+        subFeature: string;
+        element: ElementNameType;
+        subElement?: SubElementNameType;
+        wholeStyle: StyleStoreType;
+      };
 }
 
 export interface ActionPayload extends ElementPropsType {

--- a/src/store/history/action.ts
+++ b/src/store/history/action.ts
@@ -2,6 +2,7 @@ import { HistoryActionType, HistoryInfoPropsType } from '../common/type';
 
 export const INIT_HISTORY = 'INIT_HISTORY' as const;
 export const ADD_LOG = 'ADD_LOG' as const;
+export const SET_CURRENT_INDEX = 'SET_CURRENT_INDEX' as const;
 
 export const initHistory = (): HistoryActionType => ({
   type: INIT_HISTORY,
@@ -11,4 +12,9 @@ export const initHistory = (): HistoryActionType => ({
 export const addLog = (info: HistoryInfoPropsType): HistoryActionType => ({
   type: ADD_LOG,
   payload: info,
+});
+
+export const setCurrentIndex = (currentIndex: number): HistoryActionType => ({
+  type: SET_CURRENT_INDEX,
+  payload: { currentIndex },
 });

--- a/src/store/history/reducer.ts
+++ b/src/store/history/reducer.ts
@@ -1,8 +1,9 @@
-import { ADD_LOG, INIT_HISTORY } from './action';
+import { ADD_LOG, INIT_HISTORY, SET_CURRENT_INDEX } from './action';
 import {
   HistoryPropsType,
   HistoryActionType,
   HistoryInfoPropsType,
+  SetIndexPayload,
 } from '../common/type';
 import getRandomId from '../../utils/getRandomId';
 
@@ -34,13 +35,11 @@ function historyReducer(
     case ADD_LOG: {
       const id = getRandomId(8);
       const newState = JSON.parse(JSON.stringify(state));
+      if (newState.log.length !== newState.currentIdx + 1) {
+        newState.log.splice(newState.currentIdx + 1);
+      }
 
-      if (newState.log.length >= 100) newState.log.shift(); // localstorage에서도 빼는 작업이 필요하겠네요!
-
-      newState.log.push({
-        id,
-        ...JSON.parse(JSON.stringify(action.payload)),
-      });
+      newState.log.push({ id, ...action.payload });
       newState.currentIdx = newState.log.length - 1;
 
       const storedLog =
@@ -49,6 +48,7 @@ function historyReducer(
           : JSON.parse(localStorage.getItem('log') as string);
 
       // TODO: localstorage update before Event(refresh, close..)
+      // localstorage에 업로드 할때 100개만 가져가면 되지 않을까요?
       if (storedLog !== undefined) {
         storedLog.push({
           id,
@@ -57,6 +57,12 @@ function historyReducer(
         localStorage.setItem('log', JSON.stringify(storedLog));
       }
 
+      return newState;
+    }
+
+    case SET_CURRENT_INDEX: {
+      const newState = JSON.parse(JSON.stringify(state));
+      newState.currentIdx = (action.payload as SetIndexPayload).currentIndex;
       return newState;
     }
 

--- a/src/store/style/action.ts
+++ b/src/store/style/action.ts
@@ -1,8 +1,13 @@
-import { ActionPayload, WholeStyleActionPayload } from '../common/type';
+import {
+  ActionPayload,
+  WholeStyleActionPayload,
+  StyleStoreType,
+} from '../common/type';
 
 export const INIT = 'INIT' as const;
 export const SET = 'SET' as const;
 export const SET_WHOLE = 'SET_WHOLE' as const;
+export const REPLACE_WHOLE = 'REPLACE_WHOLE' as const;
 
 export interface SetType {
   type: typeof SET;
@@ -12,6 +17,11 @@ export interface SetType {
 export interface SetWholeType {
   type: typeof SET_WHOLE;
   payload: WholeStyleActionPayload;
+}
+
+export interface ReplaceWholeType {
+  type: typeof REPLACE_WHOLE;
+  payload: StyleStoreType;
 }
 
 export const init = (): { type: typeof INIT } => ({
@@ -33,5 +43,12 @@ export const setWholeStyle = (
   wholeStyle: WholeStyleActionPayload
 ): SetWholeType => ({
   type: SET_WHOLE,
+  payload: wholeStyle,
+});
+
+export const replaceWholeStyle = (
+  wholeStyle: StyleStoreType
+): ReplaceWholeType => ({
+  type: REPLACE_WHOLE,
   payload: wholeStyle,
 });

--- a/src/store/style/getReducer.ts
+++ b/src/store/style/getReducer.ts
@@ -10,7 +10,7 @@ import {
   SubElementType,
 } from '../common/type';
 import { getDefaultFeature, getDefaultStyle } from './properties';
-import { INIT, SET, SET_WHOLE } from './action';
+import { INIT, SET, SET_WHOLE, REPLACE_WHOLE } from './action';
 import { checkStyleIsChanged, checkFeatureIsChanged } from './compareStyle';
 import { combineElement } from './manageCategories';
 
@@ -19,6 +19,7 @@ interface ReducerType {
 }
 
 export default function getReducer(IDX: number): ReducerType {
+  const featureName = renderingData[IDX].typeKey;
   const subFeatures = [
     'all',
     ...(renderingData[IDX].subFeatures?.map((v) => v.key) as string[]),
@@ -26,11 +27,12 @@ export default function getReducer(IDX: number): ReducerType {
 
   const initialState = subFeatures.reduce((acc: FeatureState, cur: string) => {
     acc[cur] = getDefaultFeature({
-      feature: renderingData[IDX].typeKey,
+      feature: featureName,
       subFeature: cur,
     });
     return acc;
   }, {});
+
   return function reducer(
     state: FeatureState = initialState,
     action: ActionType
@@ -38,6 +40,10 @@ export default function getReducer(IDX: number): ReducerType {
     switch (action.type) {
       case INIT:
         return initialState;
+
+      case REPLACE_WHOLE:
+        return action.payload[featureName];
+
       case SET: {
         const {
           feature,
@@ -46,7 +52,8 @@ export default function getReducer(IDX: number): ReducerType {
           subElement,
           style,
         } = action.payload;
-        if (feature !== renderingData[IDX].typeKey) return state;
+
+        if (feature !== featureName) return state;
 
         const defaultStyle = getDefaultStyle(action.payload);
         style.isChanged = checkStyleIsChanged({ defaultStyle, style });
@@ -75,8 +82,9 @@ export default function getReducer(IDX: number): ReducerType {
 
         return newState;
       }
+
       case SET_WHOLE: {
-        const inputStyle = action.payload[renderingData[IDX].typeKey];
+        const inputStyle = action.payload[featureName];
         const updateStyle = JSON.parse(JSON.stringify(initialState));
 
         if (!inputStyle) return updateStyle;


### PR DESCRIPTION
## 변경 혹은 추가된 사항
- history 관련 상태값에 currentIdx를 추가해주었습니다.
  - undo, redo 기능을 구현하는 데 이용하였습니다.
- 새로고침 후, 마지막 지도 스타일 유지를 위해 초기 렌더링시 로그의 마지막 정보에 대한 스타일 설정을 해주었습니다.
  - 이때, map이 렌더링 된 후, 해당 스타일을 적용하는 시기를 맞추기 위해 flag를 이용하였습니다. (이것이 적절한 방법인지 여쭙고 싶습니다.)
- undo, redo 기능을 구현하였습니다.
  - currentIdx값을 이용하여 currentIdx를 기준으로 한 예전의 전체 스타일과 바뀐 스타일에 접근하고 적용하여 undo 기능을 구현하였습니다.
  - currentIdx값을 이용하여 currentIdx를 기준으로 한 미래의 전체 스타일에 접근하고 적용하여 redo 기능을 구현하였습니다.