### PR TITLE
행정구역/물 레이어 초기화 데이터 추가 및 리팩토링

### DIFF
--- a/src/utils/rendering-data/layers/administrative.json
+++ b/src/utils/rendering-data/layers/administrative.json
@@ -1,0 +1,525 @@
+{
+  "administrative": [
+    {
+      "id": "admin-1-boundary-bg",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 1],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": { "line-join": "bevel" },
+      "paint": {
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          8,
+          "hsl(35, 12%, 89%)",
+          16,
+          "hsl(230, 49%, 90%)"
+        ],
+        "line-width": ["interpolate", ["linear"], ["zoom"], 7, 3.75, 12, 5.5],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 7, 0, 8, 0.75],
+        "line-dasharray": [1, 0],
+        "line-translate": [0, 0],
+        "line-blur": ["interpolate", ["linear"], ["zoom"], 3, 0, 8, 3]
+      }
+    },
+    {
+      "id": "admin-0-boundary-bg",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 0],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": {},
+      "paint": {
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 3.5, 10, 8],
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          6,
+          "hsl(35, 12%, 89%)",
+          8,
+          "hsl(230, 49%, 90%)"
+        ],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 3, 0, 4, 0.5],
+        "line-translate": [0, 0],
+        "line-blur": ["interpolate", ["linear"], ["zoom"], 3, 0, 10, 2]
+      }
+    },
+    {
+      "id": "admin-1-boundary",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 1],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": { "line-join": "round", "line-cap": "round" },
+      "paint": {
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [2, 0]],
+          7,
+          ["literal", [2, 2, 6, 2]]
+        ],
+        "line-width": ["interpolate", ["linear"], ["zoom"], 7, 0.75, 12, 1.5],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 2, 0, 3, 1],
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          3,
+          "hsl(230, 14%, 77%)",
+          7,
+          "hsl(230, 8%, 62%)"
+        ]
+      }
+    },
+    {
+      "id": "admin-0-boundary",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 0],
+        ["==", ["get", "disputed"], "false"],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": { "line-join": "round", "line-cap": "round" },
+      "paint": {
+        "line-color": "hsl(230, 8%, 51%)",
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.5, 10, 2]
+      }
+    },
+    {
+      "id": "admin-0-boundary-disputed",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        ["==", ["get", "disputed"], "true"],
+        ["==", ["get", "admin_level"], 0],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-dasharray": [1.5, 1.5],
+        "line-color": "hsl(230, 8%, 51%)",
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.5, 10, 2]
+      }
+    },
+    {
+      "id": "settlement-subdivision-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 10,
+      "maxzoom": 15,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "settlement_subdivision"],
+        ["<=", ["get", "filterrank"], 4]
+      ],
+      "layout": {
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]],
+        "text-transform": "uppercase",
+        "text-letter-spacing": [
+          "match",
+          ["get", "type"],
+          "suburb",
+          0.15,
+          ["quarter", "neighborhood"],
+          0.1,
+          0.1
+        ],
+        "text-max-width": 7,
+        "text-padding": 3,
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.5, 0, 1, 1],
+          ["zoom"],
+          11,
+          [
+            "match",
+            ["get", "type"],
+            "suburb",
+            11,
+            ["quarter", "neighborhood"],
+            10.5,
+            10.5
+          ],
+          15,
+          [
+            "match",
+            ["get", "type"],
+            "suburb",
+            17,
+            ["quarter", "neighborhood"],
+            16,
+            16
+          ]
+        ]
+      },
+      "paint": {
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 1,
+        "text-color": "hsl(230, 29%, 35%)",
+        "text-halo-blur": 0.5
+      }
+    },
+    {
+      "id": "settlement-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "maxzoom": 15,
+      "filter": [
+        "all",
+        ["<=", ["get", "filterrank"], 3],
+        ["==", ["get", "class"], "settlement"],
+        [
+          "step",
+          ["zoom"],
+          true,
+          13,
+          [">=", ["get", "symbolrank"], 11],
+          14,
+          [">=", ["get", "symbolrank"], 13]
+        ]
+      ],
+      "layout": {
+        "icon-image": [
+          "case",
+          ["==", ["get", "capital"], 2],
+          "border-dot-13",
+          ["step", ["get", "symbolrank"], "dot-11", 9, "dot-10", 11, "dot-9"]
+        ],
+        "text-font": [
+          "step",
+          ["zoom"],
+          ["literal", ["san-serif"]],
+          8,
+          [
+            "step",
+            ["get", "symbolrank"],
+            ["literal", ["san-serif"]],
+            11,
+            ["literal", ["san-serif"]]
+          ],
+          10,
+          [
+            "step",
+            ["get", "symbolrank"],
+            ["literal", ["san-serif"]],
+            12,
+            ["literal", ["san-serif"]]
+          ],
+          11,
+          [
+            "step",
+            ["get", "symbolrank"],
+            ["literal", ["san-serif"]],
+            13,
+            ["literal", ["san-serif"]]
+          ],
+          12,
+          [
+            "step",
+            ["get", "symbolrank"],
+            ["literal", ["san-serif"]],
+            15,
+            ["literal", ["san-serif"]]
+          ],
+          13,
+          ["literal", ["san-serif"]]
+        ],
+        "text-offset": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "capital"],
+            2,
+            [
+              "match",
+              ["get", "text_anchor"],
+              "bottom",
+              ["literal", [0, -0.3]],
+              "bottom-left",
+              ["literal", [0.3, -0.1]],
+              "left",
+              ["literal", [0.45, 0.1]],
+              "top-left",
+              ["literal", [0.3, 0.1]],
+              "top",
+              ["literal", [0, 0.3]],
+              "top-right",
+              ["literal", [-0.3, 0.1]],
+              "right",
+              ["literal", [-0.45, 0]],
+              "bottom-right",
+              ["literal", [-0.3, -0.1]],
+              ["literal", [0, -0.3]]
+            ],
+            [
+              "match",
+              ["get", "text_anchor"],
+              "bottom",
+              ["literal", [0, -0.25]],
+              "bottom-left",
+              ["literal", [0.2, -0.05]],
+              "left",
+              ["literal", [0.4, 0.05]],
+              "top-left",
+              ["literal", [0.2, 0.05]],
+              "top",
+              ["literal", [0, 0.25]],
+              "top-right",
+              ["literal", [-0.2, 0.05]],
+              "right",
+              ["literal", [-0.4, 0.05]],
+              "bottom-right",
+              ["literal", [-0.2, -0.05]],
+              ["literal", [0, -0.25]]
+            ]
+          ],
+          8,
+          ["literal", [0, 0]]
+        ],
+        "text-anchor": ["step", ["zoom"], ["get", "text_anchor"], 8, "center"],
+        "text-justify": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "text_anchor"],
+            ["bottom", "top"],
+            "center",
+            ["left", "bottom-left", "top-left"],
+            "left",
+            ["right", "bottom-right", "top-right"],
+            "right",
+            "center"
+          ],
+          8,
+          "center"
+        ],
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]],
+        "text-max-width": 7,
+        "text-line-height": 1.1,
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.2, 0, 0.9, 1],
+          ["zoom"],
+          3,
+          [
+            "step",
+            ["get", "symbolrank"],
+            12,
+            9,
+            11,
+            10,
+            10.5,
+            12,
+            9.5,
+            14,
+            8.5,
+            16,
+            6.5,
+            17,
+            4
+          ],
+          15,
+          [
+            "step",
+            ["get", "symbolrank"],
+            28,
+            9,
+            26,
+            10,
+            23,
+            11,
+            21,
+            12,
+            20,
+            13,
+            19,
+            15,
+            17
+          ]
+        ]
+      },
+      "paint": {
+        "text-color": "hsl(0, 0%, 0%)",
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 1,
+        "icon-opacity": ["step", ["zoom"], 1, 8, 0],
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "state-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 3,
+      "maxzoom": 9,
+      "filter": ["==", ["get", "class"], "state"],
+      "layout": {
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.85, 0.7, 0.65, 1],
+          ["zoom"],
+          4,
+          ["step", ["get", "symbolrank"], 10, 6, 9.5, 7, 9],
+          9,
+          ["step", ["get", "symbolrank"], 24, 6, 18, 7, 14]
+        ],
+        "text-transform": "uppercase",
+        "text-field": [
+          "step",
+          ["zoom"],
+          [
+            "step",
+            ["get", "symbolrank"],
+            ["coalesce", ["get", "name_ko"], ["get", "name"]],
+            5,
+            ["coalesce", ["get", "abbr"], ["get", "name_ko"], ["get", "name"]]
+          ],
+          5,
+          ["coalesce", ["get", "name_ko"], ["get", "name"]]
+        ],
+        "text-letter-spacing": 0.15,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-color": "hsl(0, 0%, 0%)",
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 1
+      }
+    },
+
+    {
+      "id": "country-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 1,
+      "maxzoom": 10,
+      "filter": ["==", ["get", "class"], "country"],
+      "layout": {
+        "icon-image": "dot-11",
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]],
+        "text-line-height": 1.1,
+        "text-max-width": 6,
+        "text-anchor": [
+          "step",
+          ["zoom"],
+          ["coalesce", ["get", "text_anchor"], "center"],
+          7,
+          "center"
+        ],
+        "text-offset": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "text_anchor"],
+            "bottom",
+            ["literal", [0, -0.25]],
+            "bottom-left",
+            ["literal", [0.2, -0.05]],
+            "left",
+            ["literal", [0.4, 0.05]],
+            "top-left",
+            ["literal", [0.2, 0.05]],
+            "top",
+            ["literal", [0, 0.25]],
+            "top-right",
+            ["literal", [-0.2, 0.05]],
+            "right",
+            ["literal", [-0.4, 0.05]],
+            "bottom-right",
+            ["literal", [-0.2, -0.05]],
+            ["literal", [0, -0.25]]
+          ],
+          7,
+          ["literal", [0, 0]]
+        ],
+        "text-justify": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "text_anchor"],
+            ["bottom", "top"],
+            "center",
+            ["left", "bottom-left", "top-left"],
+            "left",
+            ["right", "bottom-right", "top-right"],
+            "right",
+            "center"
+          ],
+          7,
+          "center"
+        ],
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.2, 0, 0.7, 1],
+          ["zoom"],
+          1,
+          ["step", ["get", "symbolrank"], 11, 4, 9, 5, 8],
+          9,
+          ["step", ["get", "symbolrank"], 28, 4, 22, 5, 21]
+        ]
+      },
+      "paint": {
+        "icon-opacity": [
+          "step",
+          ["zoom"],
+          ["case", ["has", "text_anchor"], 1, 0],
+          7,
+          0
+        ],
+        "text-color": "hsl(0, 0%, 0%)",
+        "text-halo-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          2,
+          "rgba(255,255,255,0.75)",
+          3,
+          "hsl(0, 0%, 100%)"
+        ],
+        "text-halo-width": 1.25
+      }
+    }
+  ]
+}

--- a/src/utils/rendering-data/layers/water.json
+++ b/src/utils/rendering-data/layers/water.json
@@ -1,0 +1,195 @@
+{
+  "water": [
+    {
+      "id": "water-shadow",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "water",
+      "layout": {},
+      "paint": {
+        "fill-color": "hsl(215, 84%, 69%)",
+        "fill-translate": [
+          "interpolate",
+          ["exponential", 1.2],
+          ["zoom"],
+          7,
+          ["literal", [0, 0]],
+          16,
+          ["literal", [-1, -1]]
+        ],
+        "fill-translate-anchor": "viewport"
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "water",
+      "layout": {},
+      "paint": { "fill-color": "hsl(196, 80%, 70%)" }
+    },
+    {
+      "id": "water-polygon",
+      "type": "fill",
+      "source": "polygon_source",
+      "source-layer": "polygon",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(243, 57%, 50%)",
+        "fill-opacity": 0.5,
+        "fill-translate": [
+          "interpolate",
+          ["linear", 1],
+          ["zoom"],
+          7,
+          ["literal", [0, 0]],
+          16,
+          ["literal", [-1, -1]]
+        ]
+      },
+      "filter": ["==", ["get", "type"], "water"]
+    },
+    {
+      "id": "waterway-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "natural_label",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["canal", "river", "stream"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "text-max-angle": 30,
+        "symbol-spacing": [
+          "interpolate",
+          ["linear", 1],
+          ["zoom"],
+          15,
+          250,
+          17,
+          400
+        ],
+        "text-size": ["interpolate", ["linear"], ["zoom"], 13, 12, 18, 16],
+        "symbol-placement": "line",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]]
+      },
+      "paint": { "text-color": "hsl(230, 48%, 44%)" }
+    },
+    {
+      "id": "water-line-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "natural_label",
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["bay", "ocean", "reservoir", "sea", "water"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": {
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          7,
+          ["step", ["get", "sizerank"], 24, 6, 18, 12, 12],
+          10,
+          ["step", ["get", "sizerank"], 18, 9, 12],
+          18,
+          ["step", ["get", "sizerank"], 18, 9, 16]
+        ],
+        "text-max-angle": 30,
+        "text-letter-spacing": [
+          "match",
+          ["get", "class"],
+          "ocean",
+          0.25,
+          ["sea", "bay"],
+          0.15,
+          0
+        ],
+        "symbol-placement": "line-center",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]]
+      },
+      "paint": {
+        "text-color": [
+          "match",
+          ["get", "class"],
+          ["bay", "ocean", "sea"],
+          "hsl(205, 84%, 88%)",
+          "hsl(230, 48%, 44%)"
+        ]
+      }
+    },
+    {
+      "id": "water-point-label",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "natural_label",
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["bay", "ocean", "reservoir", "sea", "water"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "Point"]
+      ],
+      "layout": {
+        "text-line-height": 1.3,
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          7,
+          ["step", ["get", "sizerank"], 24, 6, 18, 12, 12],
+          10,
+          ["step", ["get", "sizerank"], 18, 9, 12]
+        ],
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]],
+        "text-letter-spacing": [
+          "match",
+          ["get", "class"],
+          "ocean",
+          0.25,
+          ["bay", "sea"],
+          0.15,
+          0.01
+        ],
+        "text-max-width": [
+          "match",
+          ["get", "class"],
+          "ocean",
+          4,
+          "sea",
+          5,
+          ["bay", "water"],
+          7,
+          10
+        ]
+      },
+      "paint": {
+        "text-color": [
+          "match",
+          ["get", "class"],
+          ["bay", "ocean", "sea"],
+          "hsl(205, 84%, 88%)",
+          "hsl(230, 48%, 44%)"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 내용

- 행정구역/물 레이어 초기화 데이터 추가
  - 대부분 mapbox 데이터 그대로 쓰기 때문에 크게 바뀐 내용은 없음
  - 불필요한 내용 삭제 및 name_ko 지정

- map-styling > transit 리팩토링
  - 리뷰 내용에 따라 함수 분리 등 가독성 개선