### PR TITLE
FP 스타일로 layer filtering 방식 변경

### DIFF
--- a/src/store/map/layers/transit.ts
+++ b/src/store/map/layers/transit.ts
@@ -1,6 +1,6 @@
 export default [
   {
-    id: 'mapbox-airport-polygon',
+    id: 'transit-airport-section',
     type: 'fill',
     source: 'composite',
     'source-layer': 'landuse',
@@ -13,9 +13,8 @@ export default [
     filter: ['==', ['get', 'class'], 'airport'],
   },
   {
-    id: 'mapbox-airport-aeroway-polygon',
+    id: 'transit-airport-aeroway-section',
     type: 'fill',
-    metadata: {},
     source: 'composite',
     'source-layer': 'aeroway',
     minzoom: 11,
@@ -30,9 +29,8 @@ export default [
     },
   },
   {
-    id: 'mapbox-airport-aeroway-line',
+    id: 'transit-airport-aeroway-line',
     type: 'line',
-    metadata: {},
     source: 'composite',
     'source-layer': 'aeroway',
     minzoom: 9,
@@ -52,7 +50,7 @@ export default [
     },
   },
   {
-    id: 'mapbox-airport-label',
+    id: 'transit-airport-labelText',
     type: 'symbol',
     source: 'composite',
     'source-layer': 'airport_label',
@@ -113,7 +111,7 @@ export default [
     filter: ['match', ['get', 'type'], 'rail', true, false],
   },
   {
-    id: 'mapbox-rail-road-line',
+    id: 'transit-rail-road-line',
     type: 'line',
     source: 'composite',
     'source-layer': 'road',
@@ -134,7 +132,7 @@ export default [
     ],
   },
   {
-    id: 'transit-bus-label',
+    id: 'transit-bus-labelText',
     type: 'symbol',
     source: 'poi_source',
     'source-layer': 'poi',

--- a/src/utils/rendering-data/initLayerColor.ts
+++ b/src/utils/rendering-data/initLayerColor.ts
@@ -43,15 +43,15 @@ const initLayerColor: InitLayerColor = {
   'water-point-label': { color: 'hsl(230, 48%, 44%)', type: 'text' },
   'waterway-label': { color: 'hsl(230, 48%, 44%)', type: 'text' },
   //
-  'mapbox-airport-aeroway-polygon': {
+  'transit-airport-aeroway-section': {
     color: 'hsl(234, 20%, 30%)',
     type: 'fill',
   },
-  'mapbox-airport-polygon': { color: 'hsl(234, 20%, 30%)', type: 'fill' },
-  'mapbox-airport-aeroway-line': { color: 'hsl(230, 23%, 82%)', type: 'line' },
-  'mapbox-airport-label': { color: 'hsl(230, 48%, 44%)', type: 'text' },
-  'transit-bus-label': { color: 'hsl(234, 20%, 30%)', type: 'text' },
-  'mapbox-rail-road-line': { color: 'hsl(234, 20%, 30%)', type: 'line' },
+  'transit-airport-section': { color: 'hsl(234, 20%, 30%)', type: 'fill' },
+  'transit-airport-aeroway-line': { color: 'hsl(230, 23%, 82%)', type: 'line' },
+  'transit-airport-labelText': { color: 'hsl(230, 48%, 44%)', type: 'text' },
+  'transit-bus-labelText': { color: 'hsl(234, 20%, 30%)', type: 'text' },
+  'transit-rail-road-line': { color: 'hsl(234, 20%, 30%)', type: 'line' },
   'transit-rail-line': { color: 'hsl(234, 20%, 30%)', type: 'line' },
   'transit-subway-line': { color: 'hsl(192, 70%, 43%)', type: 'line' },
   'road-arterial': { color: 'hsl(0, 0%, 100%)', type: 'line' },

--- a/src/utils/rendering-data/layers/administrative.json
+++ b/src/utils/rendering-data/layers/administrative.json
@@ -1,37 +1,7 @@
 {
   "administrative": [
     {
-      "id": "admin-1-boundary-bg",
-      "type": "line",
-      "metadata": { "mapbox:group": "1444934295202.7542" },
-      "source": "composite",
-      "source-layer": "admin",
-      "filter": [
-        "all",
-        ["==", ["get", "admin_level"], 1],
-        ["==", ["get", "maritime"], "false"],
-        ["match", ["get", "worldview"], ["all", "US"], true, false]
-      ],
-      "layout": { "line-join": "bevel" },
-      "paint": {
-        "line-color": [
-          "interpolate",
-          ["linear"],
-          ["zoom"],
-          8,
-          "hsl(35, 12%, 89%)",
-          16,
-          "hsl(230, 49%, 90%)"
-        ],
-        "line-width": ["interpolate", ["linear"], ["zoom"], 7, 3.75, 12, 5.5],
-        "line-opacity": ["interpolate", ["linear"], ["zoom"], 7, 0, 8, 0.75],
-        "line-dasharray": [1, 0],
-        "line-translate": [0, 0],
-        "line-blur": ["interpolate", ["linear"], ["zoom"], 3, 0, 8, 3]
-      }
-    },
-    {
-      "id": "admin-0-boundary-bg",
+      "id": "administrative-country-bg-line",
       "type": "line",
       "metadata": { "mapbox:group": "1444934295202.7542" },
       "source": "composite",
@@ -61,7 +31,57 @@
       }
     },
     {
-      "id": "admin-1-boundary",
+      "id": "administrative-state-bg-line",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 1],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": { "line-join": "bevel" },
+      "paint": {
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          8,
+          "hsl(35, 12%, 89%)",
+          16,
+          "hsl(230, 49%, 90%)"
+        ],
+        "line-width": ["interpolate", ["linear"], ["zoom"], 7, 3.75, 12, 5.5],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 7, 0, 8, 0.75],
+        "line-dasharray": [1, 0],
+        "line-translate": [0, 0],
+        "line-blur": ["interpolate", ["linear"], ["zoom"], 3, 0, 8, 3]
+      }
+    },
+    {
+      "id": "administrative-country-line",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 0],
+        ["==", ["get", "disputed"], "false"],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": { "line-join": "round", "line-cap": "round" },
+      "paint": {
+        "line-color": "hsl(230, 8%, 51%)",
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.5, 10, 2]
+      }
+    },
+    {
+      "id": "administrative-state-line",
       "type": "line",
       "metadata": { "mapbox:group": "1444934295202.7542" },
       "source": "composite",
@@ -94,28 +114,9 @@
         ]
       }
     },
+
     {
-      "id": "admin-0-boundary",
-      "type": "line",
-      "metadata": { "mapbox:group": "1444934295202.7542" },
-      "source": "composite",
-      "source-layer": "admin",
-      "minzoom": 1,
-      "filter": [
-        "all",
-        ["==", ["get", "admin_level"], 0],
-        ["==", ["get", "disputed"], "false"],
-        ["==", ["get", "maritime"], "false"],
-        ["match", ["get", "worldview"], ["all", "US"], true, false]
-      ],
-      "layout": { "line-join": "round", "line-cap": "round" },
-      "paint": {
-        "line-color": "hsl(230, 8%, 51%)",
-        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.5, 10, 2]
-      }
-    },
-    {
-      "id": "admin-0-boundary-disputed",
+      "id": "administrative-country-line-disputed",
       "type": "line",
       "metadata": { "mapbox:group": "1444934295202.7542" },
       "source": "composite",
@@ -136,7 +137,7 @@
       }
     },
     {
-      "id": "settlement-subdivision-label",
+      "id": "administrative-settlement-subdivision-labelText",
       "type": "symbol",
       "source": "composite",
       "source-layer": "place_label",
@@ -195,7 +196,7 @@
       }
     },
     {
-      "id": "settlement-label",
+      "id": "administrative-settlement-labelText",
       "type": "symbol",
       "source": "composite",
       "source-layer": "place_label",
@@ -385,7 +386,7 @@
       }
     },
     {
-      "id": "state-label",
+      "id": "administrative-state-labelText",
       "type": "symbol",
       "source": "composite",
       "source-layer": "place_label",
@@ -427,7 +428,7 @@
     },
 
     {
-      "id": "country-label",
+      "id": "administrative-country-labelText",
       "type": "symbol",
       "source": "composite",
       "source-layer": "place_label",

--- a/src/utils/rendering-data/layers/water.json
+++ b/src/utils/rendering-data/layers/water.json
@@ -1,7 +1,7 @@
 {
   "water": [
     {
-      "id": "water-shadow",
+      "id": "water-shadow-section",
       "type": "fill",
       "source": "composite",
       "source-layer": "water",
@@ -21,7 +21,7 @@
       }
     },
     {
-      "id": "water",
+      "id": "water-section",
       "type": "fill",
       "source": "composite",
       "source-layer": "water",
@@ -52,7 +52,7 @@
       "filter": ["==", ["get", "type"], "water"]
     },
     {
-      "id": "waterway-label",
+      "id": "water-waterway-labelText",
       "type": "symbol",
       "source": "composite",
       "source-layer": "natural_label",
@@ -81,7 +81,7 @@
       "paint": { "text-color": "hsl(230, 48%, 44%)" }
     },
     {
-      "id": "water-line-label",
+      "id": "water-labelText",
       "type": "symbol",
       "source": "composite",
       "source-layer": "natural_label",
@@ -133,7 +133,7 @@
       }
     },
     {
-      "id": "water-point-label",
+      "id": "water-point-labelText",
       "type": "symbol",
       "source": "composite",
       "source-layer": "natural_label",


### PR DESCRIPTION
오전 스크럼에서 말로 잘 설명 못했던 부분인데,
@Eunsol0410 님 말씀하신 것처럼 레이어 id에 구분하는데 필요한 정보들을 넣고, 
`includes` - `filter` API 사용하면 좀더 단순하게 리팩토링 할 수 있을 것 같습니다

## 리팩토링 내용

- layer filtering  함수(`getLayerNames`)에 함수형 프로그래밍 방식 적용하여 가독성 개선
  - transit 레이어 id 변경

## TODO

- `styleKey` 판별하는 부분에서도 함수형 프로그래밍 적용하여 가독성 개선