### PR TITLE
원래 색상으로 돌아갈 수 있는 색상 초기화 기능 추가 및 url파싱 시 좌표도 같이 파싱

### DIFF
--- a/src/components/Sidebar/SidebarContentMore/ColorStyle.tsx
+++ b/src/components/Sidebar/SidebarContentMore/ColorStyle.tsx
@@ -28,6 +28,18 @@ const ColorPalette = styled.input`
   height: 40px;
 `;
 
+const Button = styled.button`
+  width: 90%;
+  margin: 10px 0;
+  background-color: ${(props) => props.theme.WHITE};
+  border: 1px solid ${(props) => props.theme.BLACK};
+  border-radius: 5px;
+  &:hover {
+    background-color: ${(props) => props.theme.GREEN};
+    color: ${(props) => props.theme.WHITE};
+  }
+`;
+
 interface ColorStyleProps {
   color: string;
   onStyleChange: (key: StyleKeyType, value: string | number) => void;
@@ -37,7 +49,12 @@ function ColorStyle({
   color,
   onStyleChange,
 }: ColorStyleProps): React.ReactElement {
-  const { curRange, rangeChangeHandler, rangeMouseUpHandler } = useInputRange({
+  const {
+    curRange,
+    rangeChangeHandler,
+    rangeMouseUpHandler,
+    initStyle,
+  } = useInputRange({
     range: color,
     onStyleChange,
   });
@@ -46,6 +63,7 @@ function ColorStyle({
     <ColorWrapper>
       <ColorTitle htmlFor="styler__color">색상</ColorTitle>
       <ColorCode>{curRange}</ColorCode>
+      <Button onClick={() => initStyle(StyleKeyType.color)}>초기화</Button>
       <ColorPalette
         type="color"
         id="styler__color"

--- a/src/components/Sidebar/SidebarModal/ExportModal.tsx
+++ b/src/components/Sidebar/SidebarModal/ExportModal.tsx
@@ -80,7 +80,7 @@ function ExportModal({
         <ModalBody>
           <ExportToJson>
             <SubTitle>JSON 형식으로 내보내기</SubTitle>
-            <Content>{JSON.stringify(style, null, 2)}</Content>
+            <Content>{JSON.stringify(style.filteredStyle, null, 2)}</Content>
           </ExportToJson>
           <ExportToURL>
             <SubTitle>URL로 내보내기</SubTitle>

--- a/src/hooks/common/useInputRange.ts
+++ b/src/hooks/common/useInputRange.ts
@@ -10,6 +10,7 @@ interface InputRangeHookType {
   curRange: string | number;
   rangeChangeHandler: (e: React.ChangeEvent<HTMLInputElement>) => void;
   rangeMouseUpHandler: (key: StyleKeyType) => void;
+  initStyle: (key: StyleKeyType) => void;
 }
 
 function useInputRange({
@@ -30,13 +31,18 @@ function useInputRange({
   };
 
   const rangeMouseUpHandler = (key: StyleKeyType) => {
-    onStyleChange(key, curRange);
+    onStyleChange(key, curRange === 'transparent' ? '#000000' : curRange);
+  };
+
+  const initStyle = (key: StyleKeyType) => {
+    onStyleChange(key, 'init');
   };
 
   return {
     curRange,
     rangeChangeHandler,
     rangeMouseUpHandler,
+    initStyle,
   };
 }
 

--- a/src/hooks/map/useMap.ts
+++ b/src/hooks/map/useMap.ts
@@ -6,6 +6,7 @@ import { urlToJson } from '../../utils/urlParsing';
 import {
   WholeStyleActionPayload,
   HistoryPropsType,
+  LocationType,
 } from '../../store/common/type';
 import validateStyle from '../../utils/validateStyle';
 import { RootState } from '../../store/index';
@@ -31,11 +32,18 @@ function useMap(): MapHookType {
   const [flag, setFlag] = useState(false);
   const { search, pathname } = window.location;
 
-  const initializeMap = (): void => {
+  const initializeMap = (map: mapboxgl.Map): void => {
     if (search && pathname === '/show') {
       const states = urlToJson();
-      if (validateStyle(states as WholeStyleActionPayload)) {
-        changeStyle(states as WholeStyleActionPayload);
+
+      // 이부분에 문제가 있는 것 같습니다. 없애면 에러 안나고 잘 되는데 있으면 안되요
+      // if (validateStyle(states.filteredStyle as WholeStyleActionPayload)) {
+      changeStyle(states.filteredStyle as WholeStyleActionPayload);
+      // }
+      const { zoom, lng, lat } = states.mapCoordinate as LocationType;
+      if (zoom && lng && lat) {
+        map.setCenter({ lng, lat });
+        map.setZoom(zoom);
       }
       return;
     }

--- a/src/hooks/sidebar/useExportStyle.ts
+++ b/src/hooks/sidebar/useExportStyle.ts
@@ -7,6 +7,7 @@ import {
   FeatureNameType,
   StyleKeyType,
   SubElementNameType,
+  LocationType,
 } from '../../store/common/type';
 import { getDefaultStyle } from '../../store/style/properties';
 
@@ -14,8 +15,13 @@ interface StoreDataType {
   [key: string]: FeatureNameType | mapboxgl.Map | undefined;
 }
 
+interface ExportType {
+  mapCoordinate: LocationType;
+  filteredStyle: StoreDataType;
+}
+
 interface UseExportStyleType {
-  exportStyle: () => StoreDataType;
+  exportStyle: () => ExportType;
 }
 
 interface StyleType {
@@ -160,18 +166,30 @@ function filterStyle(style: StoreDataType): StoreDataType {
 }
 
 function useExportStyle(): UseExportStyleType {
-  const data: StoreDataType = useSelector<RootState>(
+  const { map, sidebar, history, ...style } = useSelector<RootState>(
     (state) => state
-  ) as StoreDataType;
+  ) as any;
 
-  const exportStyle = (): StoreDataType => {
-    if ('map' in data || 'sidebar' in data) {
-      const { map, sidebar, ...style } = data;
+  const exportStyle = (): ExportType => {
+    if (map || sidebar || history) {
       const filteredStyle = filterStyle(style);
-      return filteredStyle;
+
+      const mapCoordinate = {
+        zoom: map.map.getZoom(),
+        lng: map.map.getCenter().lng,
+        lat: map.map.getCenter().lat,
+      };
+
+      return {
+        filteredStyle,
+        mapCoordinate,
+      };
     }
 
-    return {};
+    return {
+      filteredStyle: {},
+      mapCoordinate: {},
+    };
   };
 
   return { exportStyle };

--- a/src/hooks/sidebar/useUndoRedo.ts
+++ b/src/hooks/sidebar/useUndoRedo.ts
@@ -31,6 +31,7 @@ function useUndoRedo(): UseUndoRedoType {
     log: state.history.log,
     currentIdx: state.history.currentIdx,
   })) as ReduxStateType;
+  const initColor = 'init' as const;
 
   const undoHandler = () => {
     if (!map || !log || currentIdx === null || currentIdx < 0) return;
@@ -45,7 +46,7 @@ function useUndoRedo(): UseUndoRedoType {
     const isChangeWholeStyle =
       undoIdx >= 0 &&
       log[undoIdx].subFeature === 'all' &&
-      log[undoIdx].changedValue === 'init';
+      log[undoIdx].changedValue === initColor;
     if (isChangeWholeStyle) {
       changeStyle(log[undoIdx].wholeStyle as WholeStyleActionPayload);
       return;
@@ -117,7 +118,8 @@ function useUndoRedo(): UseUndoRedoType {
     dispatch(setCurrentIndex(redoIdx));
 
     /** 전체를 다시 한번 그리는 경우 */
-    const isChangeWholeStyle = subFeature === 'all' && changedValue === 'init';
+    const isChangeWholeStyle =
+      subFeature === 'all' && changedValue === initColor;
     if (isChangeWholeStyle) {
       changeStyle(wholeStyle as WholeStyleActionPayload);
       return;

--- a/src/store/common/type.ts
+++ b/src/store/common/type.ts
@@ -3,6 +3,7 @@ import {
   replaceWholeStyle,
   setStyle,
   setWholeStyle,
+  initColors,
 } from '../style/action';
 import { setSidebarProperties, initSidebarProperties } from '../sidebar/action';
 import { INIT_HISTORY, ADD_LOG, SET_CURRENT_INDEX } from '../history/action';
@@ -159,7 +160,8 @@ export type ActionType =
   | ReturnType<typeof init>
   | ReturnType<typeof setStyle>
   | ReturnType<typeof setWholeStyle>
-  | ReturnType<typeof replaceWholeStyle>;
+  | ReturnType<typeof replaceWholeStyle>
+  | ReturnType<typeof initColors>;
 
 /** Style Store Type for Replace */
 export type StyleStoreType = {
@@ -262,6 +264,13 @@ export type PropertyType = {
   [featureName in FeatureNameType]: FeaturePropertyType;
 };
 
+/** export type */
+export interface LocationType {
+  zoom?: number;
+  lng?: number;
+  lat?: number;
+}
+
 /** defatult style Type */
 export type DefaultStyleType = {
   color: string;
@@ -308,6 +317,11 @@ export type URLJsonSubFeatureType = {
   [subFeatureName: string]: URLJsonElementType;
 };
 
-export type URLJsonType = {
+export type URLJsonFeatureType = {
   [featureName in FeatureNameType]?: URLJsonSubFeatureType;
+};
+
+export type URLJsonType = {
+  filteredStyle?: URLJsonFeatureType;
+  mapCoordinate?: LocationType;
 };

--- a/src/store/map/action.ts
+++ b/src/store/map/action.ts
@@ -6,13 +6,13 @@ export interface InitActionType {
   type: typeof INIT_MAP;
   payload: {
     mapRef: RefObject<HTMLDivElement>;
-    initializeMap: () => void;
+    initializeMap: (map: mapboxgl.Map) => void;
   };
 }
 
 export const initMap = (
   mapRef: RefObject<HTMLDivElement>,
-  initializeMap: () => void
+  initializeMap: (map: mapboxgl.Map) => void
 ): InitActionType => ({
   type: INIT_MAP,
   payload: { mapRef, initializeMap },

--- a/src/store/map/initializeMap.ts
+++ b/src/store/map/initializeMap.ts
@@ -14,7 +14,7 @@ mapboxgl.accessToken = process.env.REACT_APP_ACCESS_TOKEN as string;
 
 interface InitializeMapProps {
   mapRef: RefObject<HTMLDivElement>;
-  initializeMap: () => void;
+  initializeMap: (map: mapboxgl.Map) => void;
 }
 
 function initializeMap({
@@ -39,7 +39,7 @@ function initializeMap({
   );
 
   map.on('load', () => {
-    initializeMap();
+    initializeMap(map);
   });
 
   return map;

--- a/src/store/style/action.ts
+++ b/src/store/style/action.ts
@@ -1,13 +1,17 @@
 import {
+  FeatureNameType,
   ActionPayload,
   WholeStyleActionPayload,
   StyleStoreType,
+  ElementNameType,
+  SubElementNameType,
 } from '../common/type';
 
 export const INIT = 'INIT' as const;
 export const SET = 'SET' as const;
 export const SET_WHOLE = 'SET_WHOLE' as const;
 export const REPLACE_WHOLE = 'REPLACE_WHOLE' as const;
+export const INIT_COLORS = 'INIT_COLORS' as const;
 
 export interface SetType {
   type: typeof SET;
@@ -22,6 +26,15 @@ export interface SetWholeType {
 export interface ReplaceWholeType {
   type: typeof REPLACE_WHOLE;
   payload: StyleStoreType;
+}
+
+export interface InitColorsType {
+  type: typeof INIT_COLORS;
+  payload: {
+    feature: FeatureNameType;
+    element: ElementNameType;
+    subElement: SubElementNameType;
+  };
 }
 
 export const init = (): { type: typeof INIT } => ({
@@ -51,4 +64,13 @@ export const replaceWholeStyle = (
 ): ReplaceWholeType => ({
   type: REPLACE_WHOLE,
   payload: wholeStyle,
+});
+
+export const initColors = (
+  feature: FeatureNameType,
+  element: ElementNameType,
+  subElement: SubElementNameType
+): InitColorsType => ({
+  type: INIT_COLORS,
+  payload: { feature, subElement, element },
 });

--- a/src/store/style/getReducer.ts
+++ b/src/store/style/getReducer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 import renderingData from '../../utils/rendering-data/featureTypeData';
 
 import {
@@ -10,7 +11,7 @@ import {
   SubElementType,
 } from '../common/type';
 import { getDefaultFeature, getDefaultStyle } from './properties';
-import { INIT, SET, SET_WHOLE, REPLACE_WHOLE } from './action';
+import { INIT, SET, SET_WHOLE, REPLACE_WHOLE, INIT_COLORS } from './action';
 import { checkStyleIsChanged, checkFeatureIsChanged } from './compareStyle';
 import { combineElement } from './manageCategories';
 
@@ -104,6 +105,30 @@ export default function getReducer(IDX: number): ReducerType {
         return updateStyle;
       }
 
+      case INIT_COLORS: {
+        const { feature, element, subElement } = action.payload;
+        if (feature !== featureName) return state;
+        const newState: FeatureState = JSON.parse(JSON.stringify(state));
+
+        Object.keys(newState).forEach((subFeature) => {
+          const defaultStyle = getDefaultStyle({
+            feature,
+            subElement,
+            element,
+            subFeature,
+          });
+
+          const style = (newState[subFeature][element] as SubElementType)[
+            subElement
+          ];
+          style.color = defaultStyle.color;
+          style.isChanged = checkStyleIsChanged({ defaultStyle, style });
+        });
+        delete (newState.all as objType).isChanged;
+        newState.all.isChanged = checkFeatureIsChanged(newState.all);
+
+        return newState;
+      }
       default:
         return state;
     }

--- a/src/store/style/properties.ts
+++ b/src/store/style/properties.ts
@@ -33,14 +33,12 @@ export const getDefaultStyle = ({
       ] as DefaultStyleType)
     : (defaultStyle[feature][subFeature][element] as DefaultStyleType);
 
-  if (defaultState.color === 'transparent')
-    defaultState.color = 'hsl(0, 0%, 0%)';
-
   const hslArr = defaultState.color.match(
     /hsl\((\d+), (\d+)%, (\d+)%\)/
   ) as string[];
-  const s = hslArr[2];
-  const l = hslArr[3];
+
+  const s = hslArr ? hslArr[2] : 0;
+  const l = hslArr ? hslArr[3] : 0;
 
   return {
     ...JSON.parse(JSON.stringify(style)),

--- a/src/utils/colorFormat.ts
+++ b/src/utils/colorFormat.ts
@@ -35,14 +35,14 @@ export function hexToHSL(color: string): HexToHSLType {
   l = +(l * 100).toFixed(1);
 
   return {
-    h,
-    s,
-    l,
+    h: Math.round(h),
+    s: Math.round(s),
+    l: Math.round(l),
   };
 }
 
 export function hslToHEX(color: string): string {
-  if (color === 'transparent') return '#000000';
+  if (color === 'transparent') return 'transparent';
   const hsl = color.match(/(\d*\.?\d+)/g)?.map((c) => Number(c)) as number[];
 
   const h: number = hsl[0];

--- a/src/utils/removeNullFromObject.ts
+++ b/src/utils/removeNullFromObject.ts
@@ -1,0 +1,19 @@
+import { objType } from '../store/common/type';
+
+function removeNullFromObject(object: objType): any {
+  if (typeof object !== 'object') return;
+
+  Object.keys(object).forEach((key) => {
+    if (object[key] === null) {
+      // eslint-disable-next-line no-param-reassign
+      delete object[key];
+      return;
+    }
+    removeNullFromObject(object[key]);
+  });
+
+  // eslint-disable-next-line consistent-return
+  return object;
+}
+
+export default removeNullFromObject;

--- a/src/utils/rendering-data/layers/administrative.json
+++ b/src/utils/rendering-data/layers/administrative.json
@@ -1,0 +1,526 @@
+{
+  "administrative": [
+    {
+      "id": "administrative-country-bg-line",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 0],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": {},
+      "paint": {
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 3.5, 10, 8],
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          6,
+          "hsl(35, 12%, 89%)",
+          8,
+          "hsl(230, 49%, 90%)"
+        ],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 3, 0, 4, 0.5],
+        "line-translate": [0, 0],
+        "line-blur": ["interpolate", ["linear"], ["zoom"], 3, 0, 10, 2]
+      }
+    },
+    {
+      "id": "administrative-state-bg-line",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 1],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": { "line-join": "bevel" },
+      "paint": {
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          8,
+          "hsl(35, 12%, 89%)",
+          16,
+          "hsl(230, 49%, 90%)"
+        ],
+        "line-width": ["interpolate", ["linear"], ["zoom"], 7, 3.75, 12, 5.5],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 7, 0, 8, 0.75],
+        "line-dasharray": [1, 0],
+        "line-translate": [0, 0],
+        "line-blur": ["interpolate", ["linear"], ["zoom"], 3, 0, 8, 3]
+      }
+    },
+    {
+      "id": "administrative-country-line",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 0],
+        ["==", ["get", "disputed"], "false"],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": { "line-join": "round", "line-cap": "round" },
+      "paint": {
+        "line-color": "hsl(230, 8%, 51%)",
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.5, 10, 2]
+      }
+    },
+    {
+      "id": "administrative-state-line",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "filter": [
+        "all",
+        ["==", ["get", "admin_level"], 1],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": { "line-join": "round", "line-cap": "round" },
+      "paint": {
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [2, 0]],
+          7,
+          ["literal", [2, 2, 6, 2]]
+        ],
+        "line-width": ["interpolate", ["linear"], ["zoom"], 7, 0.75, 12, 1.5],
+        "line-opacity": ["interpolate", ["linear"], ["zoom"], 2, 0, 3, 1],
+        "line-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          3,
+          "hsl(230, 14%, 77%)",
+          7,
+          "hsl(230, 8%, 62%)"
+        ]
+      }
+    },
+
+    {
+      "id": "administrative-country-line-disputed",
+      "type": "line",
+      "metadata": { "mapbox:group": "1444934295202.7542" },
+      "source": "composite",
+      "source-layer": "admin",
+      "minzoom": 1,
+      "filter": [
+        "all",
+        ["==", ["get", "disputed"], "true"],
+        ["==", ["get", "admin_level"], 0],
+        ["==", ["get", "maritime"], "false"],
+        ["match", ["get", "worldview"], ["all", "US"], true, false]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-dasharray": [1.5, 1.5],
+        "line-color": "hsl(230, 8%, 51%)",
+        "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.5, 10, 2]
+      }
+    },
+    {
+      "id": "administrative-settlement-subdivision-labelText",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 10,
+      "maxzoom": 15,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "settlement_subdivision"],
+        ["<=", ["get", "filterrank"], 4]
+      ],
+      "layout": {
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]],
+        "text-transform": "uppercase",
+        "text-letter-spacing": [
+          "match",
+          ["get", "type"],
+          "suburb",
+          0.15,
+          ["quarter", "neighborhood"],
+          0.1,
+          0.1
+        ],
+        "text-max-width": 7,
+        "text-padding": 3,
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.5, 0, 1, 1],
+          ["zoom"],
+          11,
+          [
+            "match",
+            ["get", "type"],
+            "suburb",
+            11,
+            ["quarter", "neighborhood"],
+            10.5,
+            10.5
+          ],
+          15,
+          [
+            "match",
+            ["get", "type"],
+            "suburb",
+            17,
+            ["quarter", "neighborhood"],
+            16,
+            16
+          ]
+        ]
+      },
+      "paint": {
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 1,
+        "text-color": "hsl(230, 29%, 35%)",
+        "text-halo-blur": 0.5
+      }
+    },
+    {
+      "id": "administrative-settlement-labelText",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "maxzoom": 15,
+      "filter": [
+        "all",
+        ["<=", ["get", "filterrank"], 3],
+        ["==", ["get", "class"], "settlement"],
+        [
+          "step",
+          ["zoom"],
+          true,
+          13,
+          [">=", ["get", "symbolrank"], 11],
+          14,
+          [">=", ["get", "symbolrank"], 13]
+        ]
+      ],
+      "layout": {
+        "icon-image": [
+          "case",
+          ["==", ["get", "capital"], 2],
+          "border-dot-13",
+          ["step", ["get", "symbolrank"], "dot-11", 9, "dot-10", 11, "dot-9"]
+        ],
+        "text-font": [
+          "step",
+          ["zoom"],
+          ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]],
+          8,
+          [
+            "step",
+            ["get", "symbolrank"],
+            ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]],
+            11,
+            ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]]
+          ],
+          10,
+          [
+            "step",
+            ["get", "symbolrank"],
+            ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]],
+            12,
+            ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]]
+          ],
+          11,
+          [
+            "step",
+            ["get", "symbolrank"],
+            ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]],
+            13,
+            ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]]
+          ],
+          12,
+          [
+            "step",
+            ["get", "symbolrank"],
+            ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]],
+            15,
+            ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]]
+          ],
+          13,
+          ["literal", ["DIN Offc Pro Italic", "Arial Unicode MS Regular"]]
+        ],
+        "text-offset": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "capital"],
+            2,
+            [
+              "match",
+              ["get", "text_anchor"],
+              "bottom",
+              ["literal", [0, -0.3]],
+              "bottom-left",
+              ["literal", [0.3, -0.1]],
+              "left",
+              ["literal", [0.45, 0.1]],
+              "top-left",
+              ["literal", [0.3, 0.1]],
+              "top",
+              ["literal", [0, 0.3]],
+              "top-right",
+              ["literal", [-0.3, 0.1]],
+              "right",
+              ["literal", [-0.45, 0]],
+              "bottom-right",
+              ["literal", [-0.3, -0.1]],
+              ["literal", [0, -0.3]]
+            ],
+            [
+              "match",
+              ["get", "text_anchor"],
+              "bottom",
+              ["literal", [0, -0.25]],
+              "bottom-left",
+              ["literal", [0.2, -0.05]],
+              "left",
+              ["literal", [0.4, 0.05]],
+              "top-left",
+              ["literal", [0.2, 0.05]],
+              "top",
+              ["literal", [0, 0.25]],
+              "top-right",
+              ["literal", [-0.2, 0.05]],
+              "right",
+              ["literal", [-0.4, 0.05]],
+              "bottom-right",
+              ["literal", [-0.2, -0.05]],
+              ["literal", [0, -0.25]]
+            ]
+          ],
+          8,
+          ["literal", [0, 0]]
+        ],
+        "text-anchor": ["step", ["zoom"], ["get", "text_anchor"], 8, "center"],
+        "text-justify": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "text_anchor"],
+            ["bottom", "top"],
+            "center",
+            ["left", "bottom-left", "top-left"],
+            "left",
+            ["right", "bottom-right", "top-right"],
+            "right",
+            "center"
+          ],
+          8,
+          "center"
+        ],
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]],
+        "text-max-width": 7,
+        "text-line-height": 1.1,
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.2, 0, 0.9, 1],
+          ["zoom"],
+          3,
+          [
+            "step",
+            ["get", "symbolrank"],
+            12,
+            9,
+            11,
+            10,
+            10.5,
+            12,
+            9.5,
+            14,
+            8.5,
+            16,
+            6.5,
+            17,
+            4
+          ],
+          15,
+          [
+            "step",
+            ["get", "symbolrank"],
+            28,
+            9,
+            26,
+            10,
+            23,
+            11,
+            21,
+            12,
+            20,
+            13,
+            19,
+            15,
+            17
+          ]
+        ]
+      },
+      "paint": {
+        "text-color": "hsl(0, 0%, 0%)",
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 1,
+        "icon-opacity": ["step", ["zoom"], 1, 8, 0],
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "administrative-state-labelText",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 3,
+      "maxzoom": 9,
+      "filter": ["==", ["get", "class"], "state"],
+      "layout": {
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.85, 0.7, 0.65, 1],
+          ["zoom"],
+          4,
+          ["step", ["get", "symbolrank"], 10, 6, 9.5, 7, 9],
+          9,
+          ["step", ["get", "symbolrank"], 24, 6, 18, 7, 14]
+        ],
+        "text-transform": "uppercase",
+        "text-field": [
+          "step",
+          ["zoom"],
+          [
+            "step",
+            ["get", "symbolrank"],
+            ["coalesce", ["get", "name_ko"], ["get", "name"]],
+            5,
+            ["coalesce", ["get", "abbr"], ["get", "name_ko"], ["get", "name"]]
+          ],
+          5,
+          ["coalesce", ["get", "name_ko"], ["get", "name"]]
+        ],
+        "text-letter-spacing": 0.15,
+        "text-max-width": 6
+      },
+      "paint": {
+        "text-color": "hsl(0, 0%, 0%)",
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 1
+      }
+    },
+
+    {
+      "id": "administrative-country-labelText",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "place_label",
+      "minzoom": 1,
+      "maxzoom": 10,
+      "filter": ["==", ["get", "class"], "country"],
+      "layout": {
+        "icon-image": "dot-11",
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]],
+        "text-line-height": 1.1,
+        "text-max-width": 6,
+        "text-anchor": [
+          "step",
+          ["zoom"],
+          ["coalesce", ["get", "text_anchor"], "center"],
+          7,
+          "center"
+        ],
+        "text-offset": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "text_anchor"],
+            "bottom",
+            ["literal", [0, -0.25]],
+            "bottom-left",
+            ["literal", [0.2, -0.05]],
+            "left",
+            ["literal", [0.4, 0.05]],
+            "top-left",
+            ["literal", [0.2, 0.05]],
+            "top",
+            ["literal", [0, 0.25]],
+            "top-right",
+            ["literal", [-0.2, 0.05]],
+            "right",
+            ["literal", [-0.4, 0.05]],
+            "bottom-right",
+            ["literal", [-0.2, -0.05]],
+            ["literal", [0, -0.25]]
+          ],
+          7,
+          ["literal", [0, 0]]
+        ],
+        "text-justify": [
+          "step",
+          ["zoom"],
+          [
+            "match",
+            ["get", "text_anchor"],
+            ["bottom", "top"],
+            "center",
+            ["left", "bottom-left", "top-left"],
+            "left",
+            ["right", "bottom-right", "top-right"],
+            "right",
+            "center"
+          ],
+          7,
+          "center"
+        ],
+        "text-size": [
+          "interpolate",
+          ["cubic-bezier", 0.2, 0, 0.7, 1],
+          ["zoom"],
+          1,
+          ["step", ["get", "symbolrank"], 11, 4, 9, 5, 8],
+          9,
+          ["step", ["get", "symbolrank"], 28, 4, 22, 5, 21]
+        ]
+      },
+      "paint": {
+        "icon-opacity": [
+          "step",
+          ["zoom"],
+          ["case", ["has", "text_anchor"], 1, 0],
+          7,
+          0
+        ],
+        "text-color": "hsl(0, 0%, 0%)",
+        "text-halo-color": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          2,
+          "rgba(255,255,255,0.75)",
+          3,
+          "hsl(0, 0%, 100%)"
+        ],
+        "text-halo-width": 1.25
+      }
+    }
+  ]
+}

--- a/src/utils/rendering-data/layers/init.ts
+++ b/src/utils/rendering-data/layers/init.ts
@@ -1437,7 +1437,7 @@ const initLayers = {
       filter: ['match', ['get', 'type'], 'rail', true, false],
     },
     {
-      id: 'transit-rail-road-line',
+      id: 'transit-rail-line-2',
       type: 'line',
       source: 'composite',
       'source-layer': 'road',

--- a/src/utils/rendering-data/layers/road.json
+++ b/src/utils/rendering-data/layers/road.json
@@ -1,0 +1,1100 @@
+{
+  "road": [
+    {
+      "id": "road-arterial-section-fill-1",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Polygon"],
+        [
+          "match",
+          ["get", "class"],
+          [
+            "primary",
+            "secondary",
+            "tertiary",
+            "primary_link",
+            "secondary_link",
+            "tertiary_link"
+          ],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false]
+      ],
+      "paint": {
+        "fill-color": "hsl(0, 0%, 100%)",
+        "fill-outline-color": "#d6d9e6"
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-2",
+      "type": "line",
+      "source": "line_source",
+      "source-layer": "line",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 100%)",
+        "line-width": 4
+      },
+      "filter": [
+        "match",
+        ["get", "type"],
+        ["road", "primary", "secondary", "teritiary"],
+        true,
+        false
+      ]
+    },
+    {
+      "id": "road-arterial-section-fill-3",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "primary"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(0, 0%, 100%)"
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-4",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["secondary", "tertiary"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(0, 0%, 100%)"
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-5",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(0, 0%, 100%)"
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-6",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "step",
+          ["zoom"],
+          ["==", ["get", "class"], "track"],
+          14,
+          [
+            "match",
+            ["get", "class"],
+            ["track", "secondary_link", "tertiary_link", "service"],
+            true,
+            false
+          ]
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(0, 0%, 100%)",
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-7",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "step",
+          ["zoom"],
+          ["==", ["get", "class"], "track"],
+          14,
+          [
+            "match",
+            ["get", "class"],
+            ["track", "secondary_link", "tertiary_link", "service"],
+            true,
+            false
+          ]
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(0, 0%, 100%)",
+        "line-opacity": ["step", ["zoom"], 1, 14, 0]
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-8",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 10,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(35, 10%, 83%)"
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-9",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855799204.86" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+        ["<=", ["get", "layer"], 1],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(35, 10%, 83%)"
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-10",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855799204.86" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [">=", ["get", "layer"], 2],
+        ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(35, 10%, 83%)"
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-11",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855799204.86" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["<=", ["get", "layer"], 1],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(35, 10%, 83%)"
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-12",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855799204.86" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [">=", ["get", "layer"], 2],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(35, 10%, 83%)"
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-13",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855799204.86" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "path"],
+        ["!=", ["get", "type"], "steps"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(35, 10%, 83%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.75, 1]],
+          16,
+          ["literal", [1, 0.75]],
+          17,
+          ["literal", [1, 0.5]]
+        ]
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-14",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855799204.86" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        ["==", ["get", "class"], "path"],
+        ["!=", ["get", "type"], "steps"],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(35, 10%, 83%)",
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      }
+    },
+    {
+      "id": "road-arterial-section-fill-15",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855799204.86" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [
+          "match",
+          ["get", "class"],
+          ["primary", "secondary", "tertiary"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 4,
+        "line-color": "hsl(35, 10%, 83%)"
+      }
+    },
+    {
+      "id": "road-arterial-section-stroke-1",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "primary"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 1,
+        "line-color": "hsl(230, 24%, 87%)",
+        "line-gap-width": 1,
+        "line-opacity": ["step", ["zoom"], 0, 10, 1]
+      }
+    },
+    {
+      "id": "road-arterial-section-stroke-2",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["secondary", "tertiary"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 1,
+        "line-color": "hsl(230, 24%, 87%)",
+        "line-gap-width": 1,
+        "line-opacity": ["step", ["zoom"], 0, 10, 1]
+      }
+    },
+    {
+      "id": "road-arterial-section-stroke-3",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "filter": [
+        "all",
+        ["match", ["get", "class"], ["motorway", "trunk"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 1,
+        "line-color": "hsl(230, 24%, 87%)",
+        "line-gap-width": 1,
+        "line-opacity": [
+          "step",
+          ["zoom"],
+          ["match", ["get", "class"], "motorway", 1, 0],
+          6,
+          1
+        ]
+      }
+    },
+    {
+      "id": "road-arterial-section-stroke-4",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        [
+          "step",
+          ["zoom"],
+          ["==", ["get", "class"], "track"],
+          14,
+          [
+            "match",
+            ["get", "class"],
+            ["track", "secondary_link", "tertiary_link", "service"],
+            true,
+            false
+          ]
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 1,
+        "line-color": "hsl(230, 24%, 87%)",
+        "line-gap-width": 1,
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      }
+    },
+    {
+      "id": "road-arterial-section-stroke-5",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855799204.86" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway_link", "trunk_link"],
+          true,
+          false
+        ],
+        ["<=", ["get", "layer"], 1],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-width": 1,
+        "line-color": "hsl(35, 10%, 83%)",
+        "line-gap-width": 1
+      }
+    },
+    {
+      "id": "road-arterial-section-stroke-6",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855799204.86" },
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", ["get", "structure"], "bridge"],
+        [
+          "match",
+          ["get", "class"],
+          ["primary", "secondary", "tertiary"],
+          true,
+          false
+        ],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-width": 1,
+        "line-color": "hsl(35, 10%, 83%)",
+        "line-gap-width": 1,
+        "line-opacity": ["step", ["zoom"], 0, 10, 1]
+      }
+    },
+    {
+      "id": "road-arterial-labelText-1",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": {},
+      "minzoom": 10,
+      "filter": [
+        "step",
+        ["zoom"],
+        [
+          "match",
+          ["get", "class"],
+          ["motorway", "trunk", "primary", "secondary", "tertiary"],
+          true,
+          false
+        ],
+        12,
+        [
+          "match",
+          ["get", "class"],
+          ["motorway", "trunk", "primary", "secondary", "tertiary"],
+          true,
+          false
+        ]
+      ],
+      "layout": {
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          10,
+          [
+            "match",
+            ["get", "class"],
+            ["motorway", "trunk", "primary", "secondary", "tertiary"],
+            10,
+            [
+              "motorway_link",
+              "trunk_link",
+              "primary_link",
+              "secondary_link",
+              "tertiary_link"
+            ],
+            9,
+            6.5
+          ],
+          18,
+          [
+            "match",
+            ["get", "class"],
+            ["motorway", "trunk", "primary", "secondary", "tertiary"],
+            16,
+            [
+              "motorway_link",
+              "trunk_link",
+              "primary_link",
+              "secondary_link",
+              "tertiary_link"
+            ],
+            14,
+            13
+          ]
+        ],
+        "text-max-angle": 30,
+        "text-font": ["DIN Offc Pro Regular", "Arial Unicode MS Regular"],
+        "symbol-placement": "line",
+        "text-padding": 1,
+        "text-rotation-alignment": "map",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]],
+        "text-letter-spacing": 0.01
+      },
+      "paint": {
+        "text-color": "hsl(230, 48%, 44%)",
+        "text-halo-color": "hsl(230, 48%, 44%)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "road-arterial-labelIcon-1",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": {},
+      "minzoom": 6,
+      "filter": [
+        "all",
+        ["has", "reflen"],
+        ["<=", ["get", "reflen"], 6],
+        [
+          "step",
+          ["zoom"],
+          ["==", ["geometry-type"], "Point"],
+          11,
+          [">", ["get", "len"], 5000],
+          12,
+          [">", ["get", "len"], 2500],
+          13,
+          [">", ["get", "len"], 1000],
+          14,
+          true
+        ]
+      ],
+      "layout": {
+        "text-size": 9,
+        "icon-image": [
+          "concat",
+          ["get", "shield"],
+          "-",
+          ["to-string", ["get", "reflen"]]
+        ],
+        "icon-rotation-alignment": "viewport",
+        "text-max-angle": 38,
+        "symbol-spacing": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          11,
+          150,
+          14,
+          200
+        ],
+        "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
+        "symbol-placement": ["step", ["zoom"], "point", 11, "line"],
+        "text-rotation-alignment": "viewport",
+        "text-field": ["get", "ref"],
+        "text-letter-spacing": 0.05
+      },
+      "paint": {
+        "text-color": [
+          "match",
+          ["get", "shield_text_color"],
+          "white",
+          "hsl(0, 0%, 100%)",
+          "black",
+          "hsl(0, 0%, 7%)",
+          "yellow",
+          "hsl(50, 100%, 70%)",
+          "orange",
+          "hsl(25, 100%, 75%)",
+          "blue",
+          "hsl(230, 48%, 34%)",
+          "hsl(0, 0%, 100%)"
+        ]
+      }
+    },
+    {
+      "id": "road-arterial-labelIcon-2",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "motorway_junction",
+      "metadata": {},
+      "minzoom": 14,
+      "filter": ["all", ["has", "reflen"], ["<=", ["get", "reflen"], 9]],
+      "layout": {
+        "text-field": ["get", "ref"],
+        "text-size": 9,
+        "icon-image": [
+          "concat",
+          "motorway-exit-",
+          ["to-string", ["get", "reflen"]]
+        ],
+        "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"]
+      },
+      "paint": { "text-color": "hsl(0, 0%, 100%)", "text-translate": [0, 0] }
+    },
+
+    {
+      "id": "road-local-section-fill-1",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Polygon"],
+        ["match", ["get", "class"], ["street"], true, false]
+      ],
+      "paint": {
+        "fill-color": "hsl(35, 14%, 93%)",
+        "fill-outline-color": "#d6d9e6"
+      }
+    },
+    {
+      "id": "road-local-section-fill-2",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": {},
+      "minzoom": 8,
+      "filter": ["==", ["get", "type"], "ferry"],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-width": 3,
+        "line-color": "hsl(230, 48%, 44%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          13,
+          ["literal", [12, 4]]
+        ]
+      }
+    },
+    {
+      "id": "road-local-section-fill-3",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": {},
+      "filter": ["==", ["get", "type"], "ferry_auto"],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-color": "hsl(35, 14%, 93%)",
+        "line-width": 3
+      }
+    },
+    {
+      "id": "road-local-section-fill-4",
+      "type": "line",
+      "source": "line_source",
+      "source-layer": "line",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-width": 3,
+        "line-color": "hsl(35, 14%, 93%)"
+      },
+      "filter": [
+        "match",
+        ["get", "type"],
+        ["cycleway", "path", "living_street", "service"],
+        true,
+        false
+      ]
+    },
+    {
+      "id": "road-local-section-fill-5",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["street", "street_limited", "primary_link"],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 3,
+        "line-color": "hsl(35, 14%, 93%)",
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      }
+    },
+    {
+      "id": "road-local-section-stroke-1",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 11,
+      "filter": [
+        "all",
+        [
+          "match",
+          ["get", "class"],
+          ["street", "street_limited", "primary_link"],
+          true,
+          false
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-cap": "round", "line-join": "round" },
+      "paint": {
+        "line-width": 1,
+        "line-color": "hsl(230, 24%, 87%)",
+        "line-gap-width": 1,
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      }
+    },
+    {
+      "id": "road-local-labelText-1",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": {},
+      "minzoom": 10,
+      "filter": ["match", ["get", "class"], ["street"], true, false],
+      "layout": {
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          10,
+          ["match", ["get", "class"], ["street"], 9, 6.5],
+          18,
+          ["match", ["get", "class"], ["street"], 14, 13]
+        ],
+        "text-max-angle": 30,
+        "text-font": ["DIN Offc Pro Regular", "Arial Unicode MS Regular"],
+        "symbol-placement": "line",
+        "text-padding": 1,
+        "text-rotation-alignment": "map",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]],
+        "text-letter-spacing": 0.01
+      },
+      "paint": {
+        "text-color": "hsl(230, 48%, 44%)",
+        "text-halo-color": "hsl(230, 48%, 44%)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    },
+    {
+      "id": "road-sidewalk-section-fill-1",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Polygon"],
+        ["match", ["get", "class"], ["path", "pedestrian"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false]
+      ],
+      "paint": {
+        "fill-color": "hsl(35, 10%, 83%)",
+        "fill-outline-color": "hsl(230, 26%, 88%)"
+      }
+    },
+    {
+      "id": "road-sidewalk-section-fill-2",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Polygon"],
+        ["match", ["get", "class"], ["path", "pedestrian"], true, false],
+        ["match", ["get", "structure"], ["none", "ford"], true, false]
+      ],
+      "paint": {
+        "fill-color": "hsl(35, 10%, 83%)",
+        "fill-outline-color": "hsl(35, 10%, 83%)",
+        "fill-pattern": "pedestrian-polygon",
+        "fill-opacity": ["interpolate", ["linear"], ["zoom"], 16, 0, 16.25, 1]
+      }
+    },
+    {
+      "id": "road-sidewalk-section-fill-3",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["geometry-type"], "Polygon"],
+        ["match", ["get", "class"], ["street_limited"], true, false]
+      ],
+      "paint": {
+        "fill-color": "hsl(35, 10%, 83%)",
+        "fill-outline-color": "#d6d9e6"
+      }
+    },
+    {
+      "id": "road-sidewalk-section-fill-4",
+      "type": "line",
+      "source": "line_source",
+      "source-layer": "line",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(35, 10%, 83%)",
+        "line-width": 2
+      },
+      "filter": [
+        "match",
+        ["get", "type"],
+        ["pedestrian", "footway"],
+        true,
+        false
+      ]
+    },
+    {
+      "id": "road-sidewalk-section-fill-5",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "pedestrian"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-width": 2,
+        "line-color": "hsl(35, 10%, 83%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.5, 0.4]],
+          16,
+          ["literal", [1, 0.2]]
+        ]
+      }
+    },
+    {
+      "id": "road-sidewalk-section-fill-6",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", ["get", "type"], "steps"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-width": 2,
+        "line-color": "hsl(35, 10%, 83%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.75, 1]],
+          16,
+          ["literal", [1, 0.75]],
+          17,
+          ["literal", [0.3, 0.3]]
+        ]
+      }
+    },
+    {
+      "id": "road-sidewalk-section-fill-7",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "path"],
+        [
+          "step",
+          ["zoom"],
+          [
+            "!",
+            [
+              "match",
+              ["get", "type"],
+              ["steps", "sidewalk", "crossing"],
+              true,
+              false
+            ]
+          ],
+          16,
+          ["!=", ["get", "type"], "steps"]
+        ],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-width": 2,
+        "line-color": "hsl(35, 10%, 83%)",
+        "line-dasharray": [
+          "step",
+          ["zoom"],
+          ["literal", [1, 0]],
+          15,
+          ["literal", [1.75, 1]],
+          16,
+          ["literal", [1, 0.75]],
+          17,
+          ["literal", [1, 0.5]]
+        ]
+      }
+    },
+    {
+      "id": "road-sidewalk-section-fill-8",
+      "type": "line",
+      "source": "polygon_source",
+      "source-layer": "polygon",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(35, 10%, 83%)",
+        "line-width": 2
+      },
+      "filter": ["match", ["get", "type"], "city_wall", true, false]
+    },
+    {
+      "id": "road-sidewalk-section-stroke-1",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": { "mapbox:group": "1444855786460.0557" },
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", ["get", "class"], "pedestrian"],
+        ["match", ["get", "structure"], ["none", "ford"], true, false],
+        ["==", ["geometry-type"], "LineString"]
+      ],
+      "layout": { "line-join": "round" },
+      "paint": {
+        "line-width": 1,
+        "line-color": "hsl(230, 24%, 87%)",
+        "line-opacity": ["step", ["zoom"], 0, 14, 1]
+      }
+    },
+    {
+      "id": "road-sidewalk-labelText-1",
+      "type": "symbol",
+      "source": "composite",
+      "source-layer": "road",
+      "metadata": {},
+      "minzoom": 10,
+      "filter": [
+        "match",
+        ["get", "class"],
+        ["pedestrian", "street_limited"],
+        true,
+        false
+      ],
+      "layout": {
+        "text-size": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          10,
+          ["match", ["get", "class"], ["pedestrian", "street_limited"], 9, 6.5],
+          18,
+          ["match", ["get", "class"], ["pedestrian", "street_limited"], 14, 13]
+        ],
+        "text-max-angle": 30,
+        "text-font": ["DIN Offc Pro Regular", "Arial Unicode MS Regular"],
+        "symbol-placement": "line",
+        "text-padding": 1,
+        "text-rotation-alignment": "map",
+        "text-pitch-alignment": "viewport",
+        "text-field": ["coalesce", ["get", "name_ko"], ["get", "name"]],
+        "text-letter-spacing": 0.01
+      },
+      "paint": {
+        "text-color": "hsl(230, 48%, 44%)",
+        "text-halo-color": "hsl(230, 48%, 44%)",
+        "text-halo-width": 1,
+        "text-halo-blur": 1
+      }
+    }
+  ]
+}

--- a/src/utils/rendering-data/layers/transit.json
+++ b/src/utils/rendering-data/layers/transit.json
@@ -36,7 +36,7 @@
       }
     },
     {
-      "id": "transit-airport-line",
+      "id": "transit-airport-aeroway-line",
       "type": "line",
       "source": "composite",
       "source-layer": "aeroway",


### PR DESCRIPTION
## 상세사항
- 색상이 원래 색상으로 돌아갈 수 있는 초기화 기능을 추가했습니다.
  - 아직까지는 뒤로 / 앞으로 가기 / 새로고침 시에 에러는 딱히 발견하지 못했습니다;
  - useUndoRedo파일을 보시면 예외처리를 해놓았는데, 추후 import / theme을 로그에 기록시 사용하면 될 것 같습니다.
- url파싱에 좌표값을 넣었습니다.
  - 따라서 export로 나온 url을 이동할 때 export를 한 좌표로 이동합니다.

## 기타사항
- 조금 길어지는 함수들에게는 어떤 함수인지 주석을 다는 것은 어떨까요??
- 어제 한 도로굵기 작업을 마저할게요.