### PR TITLE
간단한 리팩토링 사항 처리

### DIFF
--- a/src/components/Map/History/History.tsx
+++ b/src/components/Map/History/History.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import styled from '../../../utils/styles/styled';
 import { RootState } from '../../../store/index';
-import { HistoryPropsType } from '../../../store/common/type';
+import { HistoryState } from '../../../store/common/type';
 import { featureName, elementName } from '../../../utils/getTypeName';
 
 const HistoryWapper = styled.div`
@@ -76,7 +76,7 @@ function History({
 }: HistoryProps): ReactElement {
   const { log, currentIdx } = useSelector<RootState>(
     (state) => state.history
-  ) as HistoryPropsType;
+  ) as HistoryState;
 
   if (!isHistoryOpen) return <></>;
 

--- a/src/components/Map/History/History.tsx
+++ b/src/components/Map/History/History.tsx
@@ -2,8 +2,8 @@ import React, { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import styled from '../../../utils/styles/styled';
 import { RootState } from '../../../store/index';
-import { HistoryPropsType, objType } from '../../../store/common/type';
-import featureTypeData from '../../../utils/rendering-data/featureTypeData';
+import { HistoryPropsType } from '../../../store/common/type';
+import { featureName, elementName } from '../../../utils/getTypeName';
 
 const HistoryWapper = styled.div`
   z-index: 30;
@@ -68,39 +68,6 @@ interface HistoryProps {
   comparisonButtonClickHandler: (id: string) => void;
   compareId: string | undefined;
 }
-
-const featureName = featureTypeData.reduce(
-  (pre, cur) => {
-    const name = pre;
-    name.feature[cur.typeKey] = cur.typeName;
-    name.subFeature[cur.typeKey] = { all: '전체' };
-    cur.subFeatures.forEach((sub) => {
-      name.subFeature[cur.typeKey][sub.key] = sub.name;
-    });
-    return name;
-  },
-  { feature: {}, subFeature: {} } as objType
-);
-
-const elementName = {
-  element: {
-    section: '구역',
-    labelText: '라벨 > 텍스트',
-    labelIcon: '라벨 > 아이콘',
-  },
-  subElement: {
-    fill: '채우기',
-    stroke: '테두리',
-  },
-  style: {
-    visibility: '가시성',
-    color: '색상',
-    weight: '굵기',
-    lightness: '채도',
-    saturation: '밝기',
-    isChanged: '',
-  },
-};
 
 function History({
   isHistoryOpen,

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -83,14 +83,14 @@ function Map({ pathname }: MapProps): React.ReactElement {
     containerRef,
     beforeMapRef,
   });
-  const { markerPos, resetMarkerPos, registerMarker } = useMarkerFeature();
+  const { markerPosition, resetMarkerPos, registerMarker } = useMarkerFeature();
 
   return (
     <MapsWrapper ref={containerRef} isPageShow={pathname === '/show'}>
       {logId && <CompareMapWrapper ref={beforeMapRef} />}
       <CurrentMapWrapper ref={afterMapRef} onClick={resetMarkerPos}>
         <MarkerPopUp
-          markerPos={markerPos}
+          markerPosition={markerPosition}
           resetMarkerPos={resetMarkerPos}
           registerMarker={registerMarker}
         />

--- a/src/components/Map/Marker/MarkerPopup.tsx
+++ b/src/components/Map/Marker/MarkerPopup.tsx
@@ -59,13 +59,13 @@ const CloseIconTag = styled(CloseIcon)`
 `;
 
 interface MarkerPopUpProps {
-  markerPos: { x: number | null; y: number | null };
+  markerPosition: { x: number | null; y: number | null };
   resetMarkerPos: () => void;
   registerMarker: ({ id, text, lngLat }: RegisterMarkerType) => void;
 }
 
 function MarkerPopUp({
-  markerPos,
+  markerPosition,
   resetMarkerPos,
   registerMarker,
 }: MarkerPopUpProps): React.ReactElement {
@@ -75,10 +75,10 @@ function MarkerPopUp({
     resetMarkerPos,
     registerMarker,
   });
-  if (markerPos.x && markerPos.y)
+  if (markerPosition.x && markerPosition.y)
     return (
       <Wrapper
-        pos={{ x: markerPos.x, y: markerPos.y }}
+        pos={{ x: markerPosition.x, y: markerPosition.y }}
         className="popup"
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/Sidebar/SidebarContentFewer/DepthItem.tsx
+++ b/src/components/Sidebar/SidebarContentFewer/DepthItem.tsx
@@ -51,7 +51,7 @@ function DepthItemPresenter({
   name,
   itemKey,
 }: ItemPresenterProps): React.ReactElement {
-  const { depth, depthRef, depthRangeHandler } = useSidebarDepthItem(itemKey);
+  const { itemDepth, depthRangeHandler } = useSidebarDepthItem(itemKey);
 
   return (
     <ItemWrapper>
@@ -62,8 +62,7 @@ function DepthItemPresenter({
         min="1"
         max="3"
         step="1"
-        ref={depthRef}
-        value={depth}
+        value={itemDepth}
         onChange={depthRangeHandler}
       />
     </ItemWrapper>

--- a/src/hooks/map/useCompareFeature.ts
+++ b/src/hooks/map/useCompareFeature.ts
@@ -55,8 +55,9 @@ function useCompareFeature({
       if (!log || !beforeMap) return;
 
       const [item] = log?.filter((val) => val.id === logId) || [];
+      const { wholeStyle } = item;
 
-      for (const feature in item.wholeStyle) {
+      for (const feature in wholeStyle) {
         setFeatureStyle({
           map: beforeMap as mapboxgl.Map,
           feature: feature as FeatureNameType,

--- a/src/hooks/map/useCompareFeature.ts
+++ b/src/hooks/map/useCompareFeature.ts
@@ -7,7 +7,7 @@ import getCompareMap from './getCompareMap';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import {
-  HistoryPropsType,
+  HistoryState,
   FeatureNameType,
   FeatureState,
 } from '../../store/common/type';
@@ -27,7 +27,7 @@ export interface useCompareFeatureProps {
   containerRef: RefObject<HTMLDivElement>;
   beforeMapRef: RefObject<HTMLDivElement>;
 }
-interface ReduxStateType extends HistoryPropsType {
+interface ReduxStateType extends HistoryState {
   map: mapboxgl.Map;
 }
 

--- a/src/hooks/map/useMap.ts
+++ b/src/hooks/map/useMap.ts
@@ -6,7 +6,7 @@ import useMarkerFeature from '../../hooks/map/useMarkerFeature';
 import { urlToJson } from '../../utils/urlParsing';
 import {
   WholeStyleActionPayload,
-  HistoryPropsType,
+  HistoryState,
   LocationType,
 } from '../../store/common/type';
 import validateStyle from '../../utils/validateStyle';
@@ -21,7 +21,7 @@ export interface MapHookType {
 }
 
 interface ReduxStateType {
-  history: HistoryPropsType;
+  history: HistoryState;
   marker: MarkerState;
 }
 

--- a/src/hooks/map/useMapTheme.ts
+++ b/src/hooks/map/useMapTheme.ts
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import {
-  DepthThemePropsType,
+  ThemDepthState,
   setThemeProperties,
 } from '../../store/depth-theme/action';
 
@@ -13,7 +13,7 @@ export interface MapThemeHookType {
 function useMapTheme(): MapThemeHookType {
   const { themeIdx } = useSelector<RootState>(
     (state) => state.depthTheme
-  ) as DepthThemePropsType;
+  ) as ThemDepthState;
 
   const dispatch = useDispatch();
 

--- a/src/hooks/map/useMarkerFeature.ts
+++ b/src/hooks/map/useMarkerFeature.ts
@@ -34,7 +34,7 @@ export interface RegisterMarkerType {
 }
 
 export interface MarkerHookType {
-  markerPos: MarkerPosType;
+  markerPosition: MarkerPosType;
   resetMarkerPos: () => void;
   registerMarker: ({ text, lngLat }: RegisterMarkerType) => void;
 }
@@ -46,7 +46,7 @@ function useMarkerFeature(): MarkerHookType {
     marker: state.marker,
   })) as ReduxStateType;
 
-  const [markerPos, setMarkerPos] = useState<MarkerPosType>({
+  const [markerPosition, setMarkerPos] = useState<MarkerPosType>({
     x: null,
     y: null,
   });
@@ -98,6 +98,7 @@ function useMarkerFeature(): MarkerHookType {
 
       newMarker.on('dragend', () => {
         const lnglat = newMarker.getLngLat();
+        // 위도, 경도 이동
         dispatch(
           updateMarker({
             id,
@@ -107,6 +108,7 @@ function useMarkerFeature(): MarkerHookType {
         );
       });
 
+      // 새로운 마커 추가
       dispatch(
         addMarker({
           id,
@@ -116,14 +118,13 @@ function useMarkerFeature(): MarkerHookType {
           instance: newMarker,
         })
       );
+      return;
     }
 
+    // 초기화 된 마커, 생성된 Marker 객체 업데이트
     dispatch(
       updateMarker({
         id,
-        text,
-        lng: lngLat.lng,
-        lat: lngLat.lat,
         instance,
       })
     );
@@ -139,7 +140,7 @@ function useMarkerFeature(): MarkerHookType {
   }, [map]);
 
   return {
-    markerPos,
+    markerPosition,
     resetMarkerPos,
     registerMarker,
   };

--- a/src/hooks/map/useMarkerFeature.ts
+++ b/src/hooks/map/useMarkerFeature.ts
@@ -73,9 +73,10 @@ function useMarkerFeature(): MarkerHookType {
     lngLat = markerLngLat,
     instance,
   }: RegisterMarkerType): void => {
-    const type = lngLat === markerLngLat ? ADD_MARKER : UPDATE_MARKER;
     if (!map || !marker) return;
     if (!lngLat.lng || !lngLat.lat) return;
+
+    // 초기화 된 마커, 생성된 Marker 객체 이벤트 핸들러 연결
     if (instance) {
       instance.addTo(map);
       instance.on('dragend', () => {
@@ -88,44 +89,33 @@ function useMarkerFeature(): MarkerHookType {
           })
         );
       });
-    }
-
-    if (type === ADD_MARKER) {
-      const newMarker = new mapboxgl.Marker({ draggable: true })
-        .setLngLat([lngLat.lng, lngLat.lat])
-        .setPopup(new mapboxgl.Popup().setHTML(`<p>${text}</p>`))
-        .addTo(map);
-
-      newMarker.on('dragend', () => {
-        const lnglat = newMarker.getLngLat();
-        // 위도, 경도 이동
-        dispatch(
-          updateMarker({
-            id,
-            lng: lnglat.lng,
-            lat: lnglat.lat,
-          })
-        );
-      });
-
-      // 새로운 마커 추가
-      dispatch(
-        addMarker({
-          id,
-          text,
-          lng: lngLat.lng,
-          lat: lngLat.lat,
-          instance: newMarker,
-        })
-      );
       return;
     }
 
-    // 초기화 된 마커, 생성된 Marker 객체 업데이트
+    const newMarker = new mapboxgl.Marker({ draggable: true })
+      .setLngLat([lngLat.lng, lngLat.lat])
+      .setPopup(new mapboxgl.Popup().setHTML(`<p>${text}</p>`))
+      .addTo(map);
+
+    newMarker.on('dragend', () => {
+      const lnglat = newMarker.getLngLat();
+      dispatch(
+        updateMarker({
+          id,
+          lng: lnglat.lng,
+          lat: lnglat.lat,
+        })
+      );
+    });
+
+    // 새로운 마커 추가
     dispatch(
-      updateMarker({
+      addMarker({
         id,
-        instance,
+        text,
+        lng: lngLat.lng,
+        lat: lngLat.lat,
+        instance: newMarker,
       })
     );
   };

--- a/src/hooks/sidebar/useDetailType.ts
+++ b/src/hooks/sidebar/useDetailType.ts
@@ -5,7 +5,7 @@ import {
   ElementNameType,
   SubElementNameType,
   FeatureType,
-  PayloadPropsType,
+  SidebarState,
 } from '../../store/common/type';
 
 interface UseDetailTypeProps {
@@ -36,7 +36,7 @@ function useDetailType({
 }: UseDetailTypeProps): UseDetailHookType {
   const { feature, subFeature, element, subElement } = useSelector<RootState>(
     (state) => state.sidebar
-  ) as PayloadPropsType;
+  ) as SidebarState;
 
   const detail = useSelector<RootState>((state) => {
     if (!feature || !subFeature) {

--- a/src/hooks/sidebar/useFeatureTypeItem.ts
+++ b/src/hooks/sidebar/useFeatureTypeItem.ts
@@ -3,7 +3,7 @@ import { RootState } from '../../store';
 import {
   FeatureState,
   FeatureNameType,
-  PayloadPropsType,
+  SidebarState,
 } from '../../store/common/type';
 
 interface useFeatureTypeItemType {
@@ -21,7 +21,7 @@ function useFeatureTypeItem({
 }: useFeatureTypeItemProps): useFeatureTypeItemType {
   const { feature, subFeature } = useSelector<RootState>(
     (state) => state.sidebar
-  ) as PayloadPropsType;
+  ) as SidebarState;
   const featureList = useSelector<RootState>(
     (state) => state[featureName]
   ) as FeatureState;

--- a/src/hooks/sidebar/useSidebarDepthItem.ts
+++ b/src/hooks/sidebar/useSidebarDepthItem.ts
@@ -9,25 +9,21 @@ import {
   SubElementNameType,
   SubFeatureActionPayload,
 } from '../../store/common/type';
-import {
-  ThemDepthState,
-  setShowDepthProperties,
-} from '../../store/depth-theme/action';
+import { setShowDepthProperties } from '../../store/depth-theme/action';
 import { applyVisibility, VisibilityType } from '../../utils/applyStyle';
 import initLayers from '../../utils/rendering-data/layers/init';
 import useWholeStyle from '../common/useWholeStyle';
 
 export enum DepthItemKeyTypes {
-  administrative = 'administrative',
-  road = 'road',
+  administrative = 'administrativeDepth',
+  road = 'roadDepth',
 }
 
 type IdFilterNames = RoadNameType | AdministrativeNameType;
 
 interface useSidebarDepthItemType {
-  depth: number;
-  depthRef: RefObject<HTMLInputElement>;
-  depthRangeHandler: () => void;
+  itemDepth: number;
+  depthRangeHandler: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 type changeableLayersByDepthType = {
@@ -117,26 +113,32 @@ const getChangeStyleProps = (
   return featurePayload;
 };
 
+interface ReduxStateType {
+  map: mapboxgl.Map;
+  itemDepth: number;
+}
+
 function useSidebarDepthItem(
   itemKey: DepthItemKeyTypes
 ): useSidebarDepthItemType {
-  const { roadDepth, administrativeDepth } = useSelector<RootState>(
-    (state) => state.depthTheme
-  ) as ThemDepthState;
-
-  const [featureLayers, depth] = (itemKey === DepthItemKeyTypes.road
-    ? [roadLayerIds, roadDepth]
-    : [administrativeLayerIds, administrativeDepth]) as [string[], number];
-
   const dispatch = useDispatch();
-  const depthRef = useRef<HTMLInputElement>(null);
-  const map = useSelector<RootState>((state) => state.map.map) as mapboxgl.Map;
+  const { map, itemDepth } = useSelector<RootState>((state) => ({
+    map: state.map.map,
+    itemDepth:
+      itemKey === DepthItemKeyTypes.road
+        ? state.depthTheme.roadDepth
+        : state.depthTheme.administrativeDepth,
+  })) as ReduxStateType;
+
+  const featureLayers =
+    itemKey === DepthItemKeyTypes.road ? roadLayerIds : administrativeLayerIds;
+
   const { getWholeStyle, replaceStyle } = useWholeStyle();
 
-  const depthRangeHandler = () => {
-    const changedDepth = Number(depthRef.current?.value);
+  const depthRangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const changedDepth = Number(e.target.value);
     const [visibility, depthRange] = getVisibilityAndDepthRange(
-      depth,
+      itemDepth,
       changedDepth
     );
     const currentStyleState = getWholeStyle();
@@ -163,8 +165,7 @@ function useSidebarDepthItem(
   };
 
   return {
-    depth,
-    depthRef,
+    itemDepth,
     depthRangeHandler,
   };
 }

--- a/src/hooks/sidebar/useSidebarDepthItem.ts
+++ b/src/hooks/sidebar/useSidebarDepthItem.ts
@@ -10,7 +10,7 @@ import {
   SubFeatureActionPayload,
 } from '../../store/common/type';
 import {
-  DepthThemePropsType,
+  ThemDepthState,
   setShowDepthProperties,
 } from '../../store/depth-theme/action';
 import { applyVisibility, VisibilityType } from '../../utils/applyStyle';
@@ -122,7 +122,7 @@ function useSidebarDepthItem(
 ): useSidebarDepthItemType {
   const { roadDepth, administrativeDepth } = useSelector<RootState>(
     (state) => state.depthTheme
-  ) as DepthThemePropsType;
+  ) as ThemDepthState;
 
   const [featureLayers, depth] = (itemKey === DepthItemKeyTypes.road
     ? [roadLayerIds, roadDepth]

--- a/src/hooks/sidebar/useSidebarDepthItem.ts
+++ b/src/hooks/sidebar/useSidebarDepthItem.ts
@@ -1,4 +1,3 @@
-import { RefObject, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../store';
 import {

--- a/src/hooks/sidebar/useSidebarType.ts
+++ b/src/hooks/sidebar/useSidebarType.ts
@@ -8,7 +8,7 @@ import {
   FeatureNameType,
   ElementNameType,
   SubElementNameType,
-  PayloadPropsType,
+  SidebarState,
   SidebarProperties,
 } from '../../store/common/type';
 
@@ -25,7 +25,7 @@ function useSidebarType(): SidebarHookType {
   const dispatch = useDispatch();
   const sidebarStates = useSelector<RootState>(
     (state) => state.sidebar
-  ) as PayloadPropsType;
+  ) as SidebarState;
   const { feature, subFeature, element, subElement } = sidebarStates;
 
   const sidebarTypeClickHandler = (name: FeatureNameType | ElementNameType) => {

--- a/src/hooks/sidebar/useStyleType.ts
+++ b/src/hooks/sidebar/useStyleType.ts
@@ -8,8 +8,8 @@ import {
   StyleKeyType,
   ElementNameType,
   SubElementNameType,
-  PayloadPropsType,
-  HistoryPropsType,
+  SidebarState,
+  HistoryState,
   StyleStoreType,
 } from '../../store/common/type';
 import { setStyle, initColors } from '../../store/style/action';
@@ -87,8 +87,8 @@ interface changedObjType {
 
 interface ReduxStateType {
   map: mapboxgl.Map;
-  sidebar: PayloadPropsType;
-  history: HistoryPropsType;
+  sidebar: SidebarState;
+  history: HistoryState;
   features: StyleStoreType;
 }
 

--- a/src/hooks/sidebar/useUndoRedo.ts
+++ b/src/hooks/sidebar/useUndoRedo.ts
@@ -2,7 +2,7 @@ import mapboxgl from 'mapbox-gl';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../store';
 import {
-  HistoryPropsType,
+  HistoryState,
   SubElementNameType,
   StyleType,
   SubElementType,
@@ -19,7 +19,7 @@ interface UseUndoRedoType {
   redoHandler: () => void;
 }
 
-interface ReduxStateType extends HistoryPropsType {
+interface ReduxStateType extends HistoryState {
   map: mapboxgl.Map;
 }
 

--- a/src/store/common/type.ts
+++ b/src/store/common/type.ts
@@ -175,7 +175,7 @@ export interface HistoryInfoPropsType {
   wholeStyle: StyleStoreType;
 }
 
-export interface HistoryPropsType {
+export interface HistoryState {
   log?: HistoryInfoPropsType[];
   currentIdx: number | null;
 }
@@ -203,7 +203,7 @@ export interface ActionPayload extends ElementPropsType {
   style: StyleType;
 }
 
-export interface PayloadPropsType {
+export interface SidebarState {
   key: 'feature' | 'subFeature' | 'element' | 'subElement';
   feature: FeatureNameType | null;
   subFeature: string | null;

--- a/src/store/depth-theme/action.ts
+++ b/src/store/depth-theme/action.ts
@@ -3,30 +3,35 @@ import { DepthItemKeyTypes } from '../../hooks/sidebar/useSidebarDepthItem';
 export const SET_SHOW_DEPTH_PROPERTIES = 'SET_SHOW_DEPTH_PROPERTIES' as const;
 export const SET_THEME_PROPERTIES = 'SET_THEME_PROPERTIES' as const;
 
-export interface DepthThemePropsType {
-  selectedFeature?: DepthItemKeyTypes;
-  selectedDepth?: number;
-  roadDepth?: number;
-  administrativeDepth?: number;
-  themeIdx?: number;
+export interface DepthPropsType {
+  selectedFeature: DepthItemKeyTypes;
+  selectedDepth: number;
 }
 
+export interface ThemePropsType {
+  themeIdx: number;
+}
+
+export interface ThemDepthState extends ThemePropsType {
+  roadDepth: number;
+  administrativeDepth: number;
+}
 export interface DepthThemeActionType {
   type: typeof SET_SHOW_DEPTH_PROPERTIES | typeof SET_THEME_PROPERTIES;
-  payload: DepthThemePropsType;
+  payload: DepthPropsType | ThemePropsType;
 }
 
 export const setShowDepthProperties = ({
   selectedFeature,
   selectedDepth,
-}: DepthThemePropsType): DepthThemeActionType => ({
+}: DepthPropsType): DepthThemeActionType => ({
   type: SET_SHOW_DEPTH_PROPERTIES,
   payload: { selectedFeature, selectedDepth },
 });
 
 export const setThemeProperties = ({
   themeIdx,
-}: DepthThemePropsType): DepthThemeActionType => ({
+}: ThemePropsType): DepthThemeActionType => ({
   type: SET_THEME_PROPERTIES,
   payload: { themeIdx },
 });

--- a/src/store/depth-theme/reducer.ts
+++ b/src/store/depth-theme/reducer.ts
@@ -2,38 +2,35 @@
 import { DepthItemKeyTypes } from '../../hooks/sidebar/useSidebarDepthItem';
 import {
   DepthThemeActionType,
-  DepthThemePropsType,
+  ThemDepthState,
+  DepthPropsType,
+  ThemePropsType,
   SET_SHOW_DEPTH_PROPERTIES,
   SET_THEME_PROPERTIES,
 } from './action';
 
-const initialState: DepthThemePropsType = {
-  selectedFeature: DepthItemKeyTypes.road,
+const initialState: ThemDepthState = {
   roadDepth: 3,
   administrativeDepth: 3,
   themeIdx: 0,
 };
 
 function depthThemeReducer(
-  state: DepthThemePropsType = initialState,
+  state: ThemDepthState = initialState,
   action: DepthThemeActionType
-): DepthThemePropsType {
+): ThemDepthState {
   const { type, payload } = action;
 
   switch (type) {
     case SET_SHOW_DEPTH_PROPERTIES:
-      const { selectedFeature, selectedDepth } = payload;
-      const changedDepth =
-        selectedFeature === DepthItemKeyTypes.road
-          ? { roadDepth: selectedDepth }
-          : { administrativeDepth: selectedDepth };
+      const { selectedFeature, selectedDepth } = payload as DepthPropsType;
       return {
         ...state,
-        ...changedDepth,
+        [selectedFeature]: selectedDepth,
       };
 
     case SET_THEME_PROPERTIES:
-      const { themeIdx } = payload;
+      const { themeIdx } = payload as ThemePropsType;
       return {
         ...state,
         themeIdx,

--- a/src/store/depth-theme/reducer.ts
+++ b/src/store/depth-theme/reducer.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-case-declarations */
-import { DepthItemKeyTypes } from '../../hooks/sidebar/useSidebarDepthItem';
 import {
   DepthThemeActionType,
   ThemDepthState,
@@ -23,7 +22,14 @@ function depthThemeReducer(
 
   switch (type) {
     case SET_SHOW_DEPTH_PROPERTIES:
+      console.log('here');
+
       const { selectedFeature, selectedDepth } = payload as DepthPropsType;
+      console.log(selectedFeature, selectedDepth);
+      console.log({
+        ...state,
+        [selectedFeature]: selectedDepth,
+      });
       return {
         ...state,
         [selectedFeature]: selectedDepth,

--- a/src/store/history/reducer.ts
+++ b/src/store/history/reducer.ts
@@ -1,6 +1,6 @@
 import { ADD_LOG, INIT_HISTORY, SET_CURRENT_INDEX } from './action';
 import {
-  HistoryPropsType,
+  HistoryState,
   HistoryActionType,
   HistoryInfoPropsType,
   SetIndexPayload,
@@ -9,15 +9,15 @@ import getRandomId from '../../utils/getRandomId';
 
 const logKey = 'log' as const;
 
-const initialState: HistoryPropsType = {
+const initialState: HistoryState = {
   log: [],
   currentIdx: null,
 };
 
 function historyReducer(
-  state: HistoryPropsType = initialState,
+  state: HistoryState = initialState,
   action: HistoryActionType
-): HistoryPropsType {
+): HistoryState {
   switch (action.type) {
     case INIT_HISTORY: {
       const localStorageLog = JSON.parse(

--- a/src/store/map/reducer.ts
+++ b/src/store/map/reducer.ts
@@ -2,18 +2,18 @@ import { InitActionType, INIT_MAP } from './action';
 import mapboxgl from 'mapbox-gl';
 import initializeMap from './initializeMap';
 
-export interface MapType {
+export interface MapState {
   map: mapboxgl.Map | null;
 }
 
-const initialState: MapType = {
+const initialState: MapState = {
   map: null,
 };
 
 function mapReducer(
-  state: MapType = initialState,
+  state: MapState = initialState,
   action: InitActionType
-): MapType {
+): MapState {
   switch (action.type) {
     case INIT_MAP: {
       const map = initializeMap({

--- a/src/store/marker/action.ts
+++ b/src/store/marker/action.ts
@@ -29,7 +29,6 @@ export interface MarkerUpdateType {
   id: string;
   lng?: number;
   lat?: number;
-  text?: string;
   instance?: mapboxgl.Marker;
 }
 
@@ -51,26 +50,16 @@ export const initMarker = (): MarkerActionType => ({
   payload: null,
 });
 
-export const addMarker = ({
-  id,
-  lng,
-  lat,
-  text,
-  instance,
-}: MarkerType): MarkerActionType => ({
+export const addMarker = (inputPayload: MarkerType): MarkerActionType => ({
   type: ADD_MARKER,
-  payload: { id, lng, lat, text, instance },
+  payload: inputPayload,
 });
 
-export const updateMarker = ({
-  id,
-  lng,
-  lat,
-  text,
-  instance,
-}: MarkerUpdateType): MarkerActionType => ({
+export const updateMarker = (
+  inputPayload: MarkerUpdateType
+): MarkerActionType => ({
   type: UPDATE_MARKER,
-  payload: { id, lng, lat, text, instance },
+  payload: inputPayload,
 });
 
 export const removeMarker = (id: string): MarkerActionType => ({

--- a/src/store/marker/reducer.ts
+++ b/src/store/marker/reducer.ts
@@ -60,7 +60,7 @@ function markerReducer(
     }
 
     case UPDATE_MARKER: {
-      const { id, lng, lat, instance } = action.payload as MarkerType;
+      const { id, lng, lat } = action.payload as MarkerType;
 
       const targetIdx = state.markers.findIndex((item) => item.id === id);
       const { text } = state.markers[targetIdx];
@@ -69,7 +69,7 @@ function markerReducer(
         text,
         lng: lng || state.markers[targetIdx].lng,
         lat: lat || state.markers[targetIdx].lat,
-        instance: instance || state.markers[targetIdx].instance,
+        instance: state.markers[targetIdx].instance,
       };
 
       const newState = state.markers.map((marker, idx) => {

--- a/src/store/marker/reducer.ts
+++ b/src/store/marker/reducer.ts
@@ -60,12 +60,13 @@ function markerReducer(
     }
 
     case UPDATE_MARKER: {
-      const { id, text, lng, lat, instance } = action.payload as MarkerType;
+      const { id, lng, lat, instance } = action.payload as MarkerType;
 
       const targetIdx = state.markers.findIndex((item) => item.id === id);
+      const { text } = state.markers[targetIdx];
       const input = {
         id,
-        text: text || state.markers[targetIdx].text,
+        text,
         lng: lng || state.markers[targetIdx].lng,
         lat: lat || state.markers[targetIdx].lat,
         instance: instance || state.markers[targetIdx].instance,

--- a/src/store/sidebar/action.ts
+++ b/src/store/sidebar/action.ts
@@ -1,11 +1,11 @@
-import { PayloadPropsType } from '../common/type';
+import { SidebarState } from '../common/type';
 
 export const SET_SIDEBAR_PROPERTIES = 'SET_SIDEBAR_PROPERTIES' as const;
 export const INIT_SIDEBAR_PROPERTIES = 'INIT_SIDEBAR_PROPERTIES' as const;
 
 export interface SidebarActionType {
   type: typeof SET_SIDEBAR_PROPERTIES | typeof INIT_SIDEBAR_PROPERTIES;
-  payload: PayloadPropsType;
+  payload: SidebarState;
 }
 
 export const setSidebarProperties = ({
@@ -14,7 +14,7 @@ export const setSidebarProperties = ({
   subFeature,
   element,
   subElement,
-}: PayloadPropsType): SidebarActionType => ({
+}: SidebarState): SidebarActionType => ({
   type: SET_SIDEBAR_PROPERTIES,
   payload: { key, feature, subFeature, element, subElement },
 });
@@ -25,7 +25,7 @@ export const initSidebarProperties = ({
   subFeature,
   element,
   subElement,
-}: PayloadPropsType): SidebarActionType => ({
+}: SidebarState): SidebarActionType => ({
   type: INIT_SIDEBAR_PROPERTIES,
   payload: { key, feature, subFeature, element, subElement },
 });

--- a/src/store/sidebar/reducer.ts
+++ b/src/store/sidebar/reducer.ts
@@ -1,7 +1,7 @@
-import { PayloadPropsType, SidebarActionType } from '../common/type';
+import { SidebarState, SidebarActionType } from '../common/type';
 import { SET_SIDEBAR_PROPERTIES, INIT_SIDEBAR_PROPERTIES } from './action';
 
-const initialState: PayloadPropsType = {
+const initialState: SidebarState = {
   key: 'feature',
   feature: null,
   subFeature: null,
@@ -10,9 +10,9 @@ const initialState: PayloadPropsType = {
 };
 
 function sidebarReducer(
-  state: PayloadPropsType = initialState,
+  state: SidebarState = initialState,
   action: SidebarActionType
-): PayloadPropsType {
+): SidebarState {
   switch (action.type) {
     case SET_SIDEBAR_PROPERTIES: {
       return {

--- a/src/utils/getTypeName.ts
+++ b/src/utils/getTypeName.ts
@@ -1,0 +1,42 @@
+import {
+  ElementNameType,
+  SubElementNameType,
+  StyleKeyType,
+  objType,
+} from '../store/common/type';
+import featureTypeData from './rendering-data/featureTypeData';
+
+const featureName = featureTypeData.reduce(
+  (pre, cur) => {
+    const name = pre;
+    name.feature[cur.typeKey] = cur.typeName;
+    name.subFeature[cur.typeKey] = { all: '전체' };
+    cur.subFeatures.forEach((sub) => {
+      name.subFeature[cur.typeKey][sub.key] = sub.name;
+    });
+    return name;
+  },
+  { feature: {}, subFeature: {} } as objType
+);
+
+const elementName = {
+  element: {
+    [ElementNameType.section]: '구역',
+    [ElementNameType.labelText]: '라벨 > 텍스트',
+    [ElementNameType.labelIcon]: '라벨 > 아이콘',
+  },
+  subElement: {
+    [SubElementNameType.fill]: '채우기',
+    [SubElementNameType.stroke]: '테두리',
+  },
+  style: {
+    [StyleKeyType.visibility]: '가시성',
+    [StyleKeyType.color]: '색상',
+    [StyleKeyType.weight]: '굵기',
+    [StyleKeyType.saturation]: '채도',
+    [StyleKeyType.lightness]: '밝기',
+    [StyleKeyType.isChanged]: '',
+  },
+};
+
+export { featureName, elementName };


### PR DESCRIPTION
## 주요 사항
- 기존 Marker Reducer에서 text, instance 업데이트가 포함되어 있었는데, 이제 필요하지 않아 뺐습니다.
- useMarkerFeature에서 리팩토링하면서 제거되지 않은 사항이 있어서 지웠습니다.
- depthTheme 리듀서의 액션 타입이 하나로 다 모여있어서 분리하고, 상태에서도 불필요한 건 뺐습니다.
- useSidebarDepth에서 useRef 사용을 이벤트 객체 받아서 처리하고, 도로/행정구역 체크를 useSelector에서 상태 조회와 함께 되도록 해서 반복 잡업을 줄여보았습니다.
- 리듀서 상태 타입의 네이밍을 통일시켰습니다.

## 참고 사항
- 그외에도 리뷰 받았던 내용을 반영한 자잘한 리팩토링이 있습니다. 
- 뭔가 많이 변한 것처럼 보이지만 사실상 단순 변경 사항이 대부부이라서 이해하기 어려우시진 않을 것 같습니다.
- ❗❗❗ 동일한 내용을 하나의 커밋에 처리했으니, 커밋을 단위로 보시면 좋을 것 같습니다. ❗❗❗ 