### PR TITLE
marker 우클릭 삭제기능 추가 / marker 수 제한 추가 / marker bug fix

### DIFF
--- a/src/components/Map/Marker/MarkerPopup.tsx
+++ b/src/components/Map/Marker/MarkerPopup.tsx
@@ -5,6 +5,7 @@ import useMarkerPopUp from '../../../hooks/map/useMarkerPopUp';
 import { RegisterMarkerType } from '../../../hooks/map/useMarkerFeature';
 import CloseIcon from '../../Icon/CloseIcon';
 
+const LIMIT_LENGTH = 10;
 interface WrapperProps {
   pos: {
     x: number | null;
@@ -88,7 +89,7 @@ function MarkerPopUp({
             <CloseIconTag onClick={resetMarkerPos} />
           </PopUpHeader>
           <MarkerInput onChange={onInputChange} />
-          {inputText.length > 10 ? (
+          {inputText.length > LIMIT_LENGTH ? (
             <div>10자 이하의 텍스트 입력만 가능합니다.</div>
           ) : (
             <OkButton type="button" onClick={onClickButton}>

--- a/src/hooks/map/useMarkerFeature.ts
+++ b/src/hooks/map/useMarkerFeature.ts
@@ -9,8 +9,9 @@ import {
   updateMarker,
   removeMarker,
   ADD_MARKER,
-  UPDATE_MARKER,
 } from '../../store/marker/action';
+
+const PRINT_MARKER_AFTER_INIT = 'printMarkerAfterInit';
 
 interface ReduxStateType {
   map: mapboxgl.Map;
@@ -74,7 +75,7 @@ function useMarkerFeature(): MarkerHookType {
     lngLat = markerLngLat,
     instance,
   }: RegisterMarkerType): void => {
-    const type = lngLat === markerLngLat ? ADD_MARKER : UPDATE_MARKER;
+    const type = lngLat === markerLngLat ? ADD_MARKER : PRINT_MARKER_AFTER_INIT;
     if (!map || !marker) return;
     if (!lngLat.lng || !lngLat.lat) return;
     if (instance) {
@@ -132,16 +133,6 @@ function useMarkerFeature(): MarkerHookType {
         })
       );
     }
-
-    dispatch(
-      updateMarker({
-        id,
-        text,
-        lng: lngLat.lng,
-        lat: lngLat.lat,
-        instance,
-      })
-    );
   };
 
   useEffect(() => {

--- a/src/hooks/map/useMarkerFeature.ts
+++ b/src/hooks/map/useMarkerFeature.ts
@@ -12,7 +12,7 @@ import {
 } from '../../store/marker/action';
 
 const PRINT_MARKER_AFTER_INIT = 'printMarkerAfterInit';
-
+const LIMIT_MARKER_NUMBER = 30;
 interface ReduxStateType {
   map: mapboxgl.Map;
   marker: MarkerState;
@@ -100,6 +100,10 @@ function useMarkerFeature(): MarkerHookType {
     }
 
     if (type === ADD_MARKER) {
+      if (marker.markers.length >= LIMIT_MARKER_NUMBER) {
+        alert(`최대 ${LIMIT_MARKER_NUMBER}개의 marker만 등록할 수 있습니다.`);
+        return;
+      }
       const newMarker = new mapboxgl.Marker({ draggable: true })
         .setLngLat([lngLat.lng, lngLat.lat])
         .setPopup(new mapboxgl.Popup().setHTML(`<p>${text}</p>`))

--- a/src/hooks/map/useMarkerFeature.ts
+++ b/src/hooks/map/useMarkerFeature.ts
@@ -7,6 +7,7 @@ import {
   MarkerState,
   addMarker,
   updateMarker,
+  removeMarker,
   ADD_MARKER,
   UPDATE_MARKER,
 } from '../../store/marker/action';
@@ -77,7 +78,6 @@ function useMarkerFeature(): MarkerHookType {
     if (!map || !marker) return;
     if (!lngLat.lng || !lngLat.lat) return;
     if (instance) {
-      instance.addTo(map);
       instance.on('dragend', () => {
         const lnglat = instance.getLngLat();
         dispatch(
@@ -88,6 +88,14 @@ function useMarkerFeature(): MarkerHookType {
           })
         );
       });
+
+      instance.getElement().addEventListener('contextmenu', (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        instance.remove();
+        dispatch(removeMarker(id));
+      });
+      instance.addTo(map);
     }
 
     if (type === ADD_MARKER) {
@@ -105,6 +113,13 @@ function useMarkerFeature(): MarkerHookType {
             lat: lnglat.lat,
           })
         );
+      });
+
+      newMarker.getElement().addEventListener('contextmenu', (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        newMarker.remove();
+        dispatch(removeMarker(id));
       });
 
       dispatch(

--- a/src/store/marker/reducer.ts
+++ b/src/store/marker/reducer.ts
@@ -26,7 +26,9 @@ function markerReducer(
 
       const newState = storedMarker.reduce(
         (acc: MarkerType[], marker: MarkerType) => {
-          const newMarker = new mapboxgl.Marker({ draggable: true })
+          const newMarker = new mapboxgl.Marker({
+            draggable: true,
+          })
             .setLngLat([marker.lng, marker.lat])
             .setPopup(new mapboxgl.Popup().setHTML(`<p>${marker.text}</p>`));
           acc.push({ ...marker, instance: newMarker });
@@ -76,7 +78,12 @@ function markerReducer(
       });
 
       const storedMarker = JSON.parse(localStorage.getItem(MARKER) as string);
-      storedMarker[targetIdx] = { id, text, lng, lat };
+      storedMarker[targetIdx] = {
+        id: input.id,
+        text: input.text,
+        lng: input.lng,
+        lat: input.lat,
+      };
       localStorage.setItem(MARKER, JSON.stringify(storedMarker));
 
       return { markers: newState };
@@ -86,12 +93,16 @@ function markerReducer(
       const newMarkers = state.markers.filter(
         (item) => item.id !== action.payload
       );
-      localStorage.setItem(
-        MARKER,
-        JSON.stringify({
-          markers: newMarkers,
-        })
+      const markerForRemove = state.markers.filter(
+        (item) => item.id === action.payload
       );
+      markerForRemove[0].instance?.remove();
+
+      const markerForLocalStorage = newMarkers.map((item) => {
+        return { id: item.id, text: item.text, lng: item.lng, lat: item.lat };
+      });
+
+      localStorage.setItem(MARKER, JSON.stringify(markerForLocalStorage));
       return {
         markers: newMarkers,
       };

--- a/src/store/marker/reducer.ts
+++ b/src/store/marker/reducer.ts
@@ -51,9 +51,9 @@ function markerReducer(
       if (!storedMarker) storedMarker = [];
       storedMarker.push({
         id,
+        text,
         lng,
         lat,
-        text,
       });
 
       localStorage.setItem(MARKER, JSON.stringify(storedMarker));


### PR DESCRIPTION
## 수정 및 변경사항
- updateMarker 시 local storage를 업데이트 해줄때 초기 함수에 넘겨진 값이 아닌, 변경된 값이 최종적으로 계산된 input 값을 직접 풀어넣어주는 형식으로 변경(기존의 형태로는 마커위치 수정시 local storage marker의 text 속성이 없어지는 bug가 있었음)
- removeMarker를 변경된 local storage 저장형식에 맞게 변경
- 마커 우클릭에 따른 삭제기능 추가
- marker 갯수 30개(변수형태로 처리)로 제한
- 현재 30개로 설정되어있는 부분은 local storage 용량 관련 논의 후 변경될 수 있음
- 주말 상황 추후 업데이트 예정..!