### PR TITLE
history reset bug fix

### DIFF
--- a/src/components/Map/History/History.tsx
+++ b/src/components/Map/History/History.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import styled from '../../../utils/styles/styled';
 import { RootState } from '../../../store/index';
 import {
@@ -10,7 +10,7 @@ import {
 } from '../../../store/common/type';
 import SetHistoryContent from './SetHistoryContent';
 import ReplaceHistoryContent from './ReplaceHistoryContent';
-import { resetHistory } from '../../../store/history/action';
+import useHistoryFeature from '../../../hooks/map/useHistoryFeature';
 
 const HistoryWapper = styled.div`
   z-index: 30;
@@ -81,18 +81,19 @@ interface HistoryProps {
   isHistoryOpen: boolean;
   comparisonButtonClickHandler: (id: string) => void;
   compareId: string | undefined;
+  setLogId: (id: string | undefined) => void;
 }
 
 function History({
   isHistoryOpen,
   comparisonButtonClickHandler,
   compareId,
+  setLogId,
 }: HistoryProps): ReactElement {
   const { log, currentIdx } = useSelector<RootState>(
     (state) => state.history
   ) as HistoryState;
-  const dispatch = useDispatch();
-
+  const { resetHistoryAndStyle } = useHistoryFeature();
   if (!isHistoryOpen) return <></>;
 
   return (
@@ -119,7 +120,12 @@ function History({
           ))
           .reverse()}
       </HistoryList>
-      <ResetHistory onClick={() => dispatch(resetHistory())}>
+      <ResetHistory
+        onClick={() => {
+          setLogId(undefined);
+          resetHistoryAndStyle();
+        }}
+      >
         History Reset
       </ResetHistory>
     </HistoryWapper>

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -61,7 +61,7 @@ function Map({ pathname }: MapProps): React.ReactElement {
   const { containerRef, afterMapRef, beforeMapRef }: MapHookType = useMap();
 
   const { isHistoryOpen, historyBtnHandler } = useHistoryFeature();
-  const { logId, comparisonButtonClickHandler } = useCompareFeature({
+  const { logId, setLogId, comparisonButtonClickHandler } = useCompareFeature({
     containerRef,
     beforeMapRef,
   });
@@ -84,6 +84,7 @@ function Map({ pathname }: MapProps): React.ReactElement {
         isHistoryOpen={isHistoryOpen}
         comparisonButtonClickHandler={comparisonButtonClickHandler}
         compareId={logId}
+        setLogId={setLogId}
       />
       <UpperButtons
         mapRef={containerRef}

--- a/src/components/Sidebar/SidebarContentMore/ColorStyle2.tsx
+++ b/src/components/Sidebar/SidebarContentMore/ColorStyle2.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from '../../../utils/styles/styled';
 // import useInputRange from '../../../hooks/common/useInputRange';
 import { StyleKeyType } from '../../../store/common/type';
-import useStyleType from '../../../hooks/sidebar/useStyleType';
+// import useStyleType from '../../../hooks/sidebar/useStyleType';
 import SaturationStyle from './SaturationStyle';
 import LightnessStyle from './LightnessStyle';
 

--- a/src/hooks/map/useCompareFeature.ts
+++ b/src/hooks/map/useCompareFeature.ts
@@ -20,6 +20,7 @@ export interface mapProps {
 
 export interface useComparisonButtonType {
   logId: string | undefined;
+  setLogId: (id: string | undefined) => void;
   comparisonButtonClickHandler: (id: string) => void;
 }
 
@@ -85,6 +86,7 @@ function useCompareFeature({
 
   return {
     logId,
+    setLogId,
     comparisonButtonClickHandler,
   };
 }

--- a/src/hooks/map/useHistoryFeature.ts
+++ b/src/hooks/map/useHistoryFeature.ts
@@ -1,15 +1,19 @@
 import { useDispatch } from 'react-redux';
-import { addLog } from '../../store/history/action';
+import { addLog, resetHistory } from '../../store/history/action';
 import { HistoryInfoPropsType } from '../../store/common/type';
 import { useState } from 'react';
+import useWholeStyle from '../../hooks/common/useWholeStyle';
 
 export interface useHistoryFeatureType {
   isHistoryOpen: boolean;
   historyBtnHandler: () => void;
   addHistory: (info: HistoryInfoPropsType) => void;
+  resetHistoryAndStyle: () => void;
 }
 
 function useHistoryFeature(): useHistoryFeatureType {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { changeStyle } = useWholeStyle();
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
 
   const dispatch = useDispatch();
@@ -22,10 +26,16 @@ function useHistoryFeature(): useHistoryFeatureType {
     dispatch(addLog(info));
   };
 
+  const resetHistoryAndStyle = () => {
+    dispatch(resetHistory());
+    changeStyle({});
+  };
+
   return {
     isHistoryOpen,
     historyBtnHandler,
     addHistory,
+    resetHistoryAndStyle,
   };
 }
 

--- a/src/hooks/sidebar/useCopyToClipboard.ts
+++ b/src/hooks/sidebar/useCopyToClipboard.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 interface CopyToClipboardType {
   url: string;

--- a/src/hooks/sidebar/useStyleType.ts
+++ b/src/hooks/sidebar/useStyleType.ts
@@ -1,4 +1,3 @@
-import mapboxgl from 'mapbox-gl';
 import { useSelector, useDispatch } from 'react-redux';
 import { useCallback, useEffect, useState } from 'react';
 import { RootState } from '../../store';


### PR DESCRIPTION
## 수정 및 추가사항
- 코어타임때의 계획은 reset시 마지막 history를 남겨주는 것이었으나, history를 reset하는데 history가 남아있는 흐름이 부자연스럽다고 생각되었습니다. 따라서 history reset 버튼을 누르면 redux log, local storage log, compare, 적용되어있는 스타일 모두 초기화됩니다.
---
- log reset을 위한 hook 추가
- local storage와 redux log를 초기화하고 스타일도 함께 초기화하는 hook 추가
- history reset 시 log, compare, style 모두 reset