### PR TITLE
불필요한 useEffect 실행 관련 리팩토링

### DIFF
--- a/src/components/Map/History/History.tsx
+++ b/src/components/Map/History/History.tsx
@@ -1,9 +1,6 @@
 import React, { ReactElement } from 'react';
-import { useSelector } from 'react-redux';
 import styled from '../../../utils/styles/styled';
-import { RootState } from '../../../store/index';
 import {
-  HistoryState,
   HistorySetLogType,
   HistoryReplaceLogType,
   ReplaceType,
@@ -90,10 +87,7 @@ function History({
   compareId,
   setLogId,
 }: HistoryProps): ReactElement {
-  const { log, currentIdx } = useSelector<RootState>(
-    (state) => state.history
-  ) as HistoryState;
-  const { resetHistoryAndStyle } = useHistoryFeature();
+  const { log, currentIdx, resetHistoryAndStyle } = useHistoryFeature();
   if (!isHistoryOpen) return <></>;
 
   return (
@@ -103,8 +97,8 @@ function History({
         <Explain>클릭 시 현재 화면과 비교 가능</Explain>
       </HistoryTitle>
       <HistoryList>
-        {(log || [])
-          .map((item, idx) => (
+        {log
+          ?.map((item, idx) => (
             <HistoryItem
               key={item.id}
               isCurrent={currentIdx === idx}

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '../../utils/styles/styled';
 import 'mapbox-gl-compare/style.css';
 import useMap, { MapHookType } from '../../hooks/map/useMap';
-import useHistoryFeature from '../../hooks/map/useHistoryFeature';
+import useHistoryMap from '../../hooks/map/useHistoryMap';
 import useCompareFeature from '../../hooks/map/useCompareFeature';
 
 import LowerButtons from './ButtonGroup/LowerButtons';
@@ -14,6 +14,10 @@ import { URLPathNameType } from '../../store/common/type';
 
 interface CurrentMapWrapperProps {
   isPageShow: boolean;
+}
+
+interface CompareMapWrapperProps {
+  isOpened: boolean;
 }
 
 const MapsWrapper = styled.div<CurrentMapWrapperProps>`
@@ -40,13 +44,14 @@ const CurrentMapWrapper = styled.div`
   }
 `;
 
-const CompareMapWrapper = styled.div`
+const CompareMapWrapper = styled.div<CompareMapWrapperProps>`
   position: absolute;
   top: 0;
 
   width: 100%;
   height: 100vh;
   background-color: ${(props) => props.theme.BLACK};
+  display: ${(props) => (props.isOpened ? 'block' : 'hidden')};
 
   canvas {
     outline: none;
@@ -58,21 +63,23 @@ interface MapProps {
 }
 
 function Map({ pathname }: MapProps): React.ReactElement {
-  const { containerRef, afterMapRef, beforeMapRef }: MapHookType = useMap();
+  const { markerPosition, resetMarkerPos, registerMarker } = useMarkerFeature();
+  const { containerRef, afterMapRef, beforeMapRef }: MapHookType = useMap({
+    registerMarker,
+  });
 
-  const { isHistoryOpen, historyBtnHandler } = useHistoryFeature();
+  const { isHistoryOpen, historyBtnHandler } = useHistoryMap();
   const { logId, setLogId, comparisonButtonClickHandler } = useCompareFeature({
     containerRef,
     beforeMapRef,
   });
-  const { markerPosition, resetMarkerPos, registerMarker } = useMarkerFeature();
 
   return (
     <MapsWrapper
       ref={containerRef}
       isPageShow={pathname === URLPathNameType.show}
     >
-      {logId && <CompareMapWrapper ref={beforeMapRef} />}
+      <CompareMapWrapper ref={beforeMapRef} isOpened={!logId} />
       <CurrentMapWrapper ref={afterMapRef} onClick={resetMarkerPos}>
         <MarkerPopUp
           markerPosition={markerPosition}

--- a/src/components/Map/Marker/MarkerPopup.tsx
+++ b/src/components/Map/Marker/MarkerPopup.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from '../../../utils/styles/styled';
 import useInputText from '../../../hooks/common/useInputText';
 import useMarkerPopUp from '../../../hooks/map/useMarkerPopUp';
-import { RegisterMarkerType } from '../../../hooks/map/useMarkerFeature';
 import CloseIcon from '../../Icon/CloseIcon';
 
 const LIMIT_LENGTH = 10;
@@ -11,6 +10,16 @@ interface WrapperProps {
     x: number | null;
     y: number | null;
   };
+}
+interface MarkerLngLatType {
+  lng: number | null;
+  lat: number | null;
+}
+export interface RegisterMarkerType {
+  id?: string;
+  text: string;
+  lngLat?: MarkerLngLatType;
+  instance?: mapboxgl.Marker;
 }
 
 const Wrapper = styled.div<WrapperProps>`

--- a/src/hooks/map/useCompareFeature.ts
+++ b/src/hooks/map/useCompareFeature.ts
@@ -37,37 +37,40 @@ function useCompareFeature({
   beforeMapRef,
 }: useCompareFeatureProps): useComparisonButtonType {
   const [logId, setLogId] = useState<string>();
+  const [beforeMap, setBeforeMap] = useState<mapboxgl.Map | null>(null);
   const { map, log } = useSelector<RootState>((state) => ({
     map: state.map.map,
     log: state.history.log,
   })) as ReduxStateType;
 
   useEffect(() => {
-    if (!map || !logId) return;
+    if (!map) return;
 
-    const beforeMap = new mapboxgl.Map({
+    const newMap = new mapboxgl.Map({
       container: beforeMapRef.current as HTMLDivElement,
       style: initLayers as mapboxgl.Style,
       center: [map.getCenter().lng, map.getCenter().lat],
       zoom: map.getZoom(),
     });
 
-    beforeMap.on('load', () => {
-      if (!log || !beforeMap) return;
+    setBeforeMap(newMap);
+  }, [map]);
 
-      const [item] = log?.filter((val) => val.id === logId) || [];
-      const { wholeStyle } = item;
+  useEffect(() => {
+    if (!map || !logId || !beforeMap || !log) return;
 
-      for (const feature in wholeStyle) {
-        setFeatureStyle({
-          map: beforeMap as mapboxgl.Map,
-          feature: feature as FeatureNameType,
-          featureState: item.wholeStyle[
-            feature as FeatureNameType
-          ] as FeatureState,
-        });
-      }
-    });
+    const [item] = log?.filter((val) => val.id === logId) || [];
+    const { wholeStyle } = item;
+
+    for (const feature in wholeStyle) {
+      setFeatureStyle({
+        map: beforeMap as mapboxgl.Map,
+        feature: feature as FeatureNameType,
+        featureState: item.wholeStyle[
+          feature as FeatureNameType
+        ] as FeatureState,
+      });
+    }
     const compare = getCompareMap(beforeMap, map, containerRef.current);
 
     // eslint-disable-next-line consistent-return

--- a/src/hooks/map/useHistoryFeature.ts
+++ b/src/hooks/map/useHistoryFeature.ts
@@ -1,58 +1,29 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { addLog, resetHistory } from '../../store/history/action';
-import { HistoryInfoPropsType, HistoryState } from '../../store/common/type';
-import { useState, useEffect } from 'react';
-import useWholeStyle from '../../hooks/common/useWholeStyle';
 import { RootState } from '../../store/index';
+import { HistoryState, HistoryInfoPropsType } from '../../store/common/type';
+import { resetHistory } from '../../store/history/action';
+import useWholeStyle from '../common/useWholeStyle';
 
 export interface useHistoryFeatureType {
-  isHistoryOpen: boolean;
-  historyBtnHandler: () => void;
-  addHistory: (info: HistoryInfoPropsType) => void;
+  log?: HistoryInfoPropsType[];
+  currentIdx: number | null;
   resetHistoryAndStyle: () => void;
 }
 
 function useHistoryFeature(): useHistoryFeatureType {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { changeStyle } = useWholeStyle();
-  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
-  const { log } = useSelector<RootState>(
+  const { log, currentIdx } = useSelector<RootState>(
     (state) => state.history
   ) as HistoryState;
+  const { changeStyle } = useWholeStyle();
 
   const dispatch = useDispatch();
-
-  const historyBtnHandler = () => {
-    setIsHistoryOpen(!isHistoryOpen);
-  };
-
-  const addHistory = (info: HistoryInfoPropsType) => {
-    dispatch(addLog(info));
-  };
 
   const resetHistoryAndStyle = () => {
     dispatch(resetHistory());
     changeStyle({});
   };
 
-  useEffect(() => {
-    window.onbeforeunload = function setLog(): void {
-      if (log !== undefined) {
-        localStorage.setItem('log', JSON.stringify(log || []));
-      }
-    };
-
-    return () => {
-      window.onbeforeunload = null;
-    };
-  }, [log]);
-
-  return {
-    isHistoryOpen,
-    historyBtnHandler,
-    addHistory,
-    resetHistoryAndStyle,
-  };
+  return { log, currentIdx, resetHistoryAndStyle };
 }
 
 export default useHistoryFeature;

--- a/src/hooks/map/useHistoryMap.ts
+++ b/src/hooks/map/useHistoryMap.ts
@@ -1,0 +1,39 @@
+import { useSelector } from 'react-redux';
+import { HistoryState } from '../../store/common/type';
+import { useState, useEffect } from 'react';
+import { RootState } from '../../store/index';
+
+export interface useHistoryMapType {
+  isHistoryOpen: boolean;
+  historyBtnHandler: () => void;
+}
+
+function useHistoryMap(): useHistoryMapType {
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const { log } = useSelector<RootState>(
+    (state) => state.history
+  ) as HistoryState;
+
+  const historyBtnHandler = () => {
+    setIsHistoryOpen(!isHistoryOpen);
+  };
+
+  useEffect(() => {
+    window.onbeforeunload = function setLog(): void {
+      if (log !== undefined) {
+        localStorage.setItem('log', JSON.stringify(log || []));
+      }
+    };
+
+    return () => {
+      window.onbeforeunload = null;
+    };
+  }, [log]);
+
+  return {
+    isHistoryOpen,
+    historyBtnHandler,
+  };
+}
+
+export default useHistoryMap;

--- a/src/hooks/map/useMap.ts
+++ b/src/hooks/map/useMap.ts
@@ -2,9 +2,7 @@ import { RefObject, useRef, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { initMap } from '../../store/map/action';
 import useWholeStyle from '../../hooks/common/useWholeStyle';
-import useMarkerFeature, {
-  getInitialMarkersFromLocalStorage,
-} from '../../hooks/map/useMarkerFeature';
+import { RegisterMarkerType } from '../../hooks/map/useMarkerFeature';
 import { urlToJson } from '../../utils/urlParsing';
 import validateStyle from '../../utils/validateStyle';
 import {
@@ -16,6 +14,7 @@ import {
 import { RootState } from '../../store/index';
 import { initMarker, MarkerState } from '../../store/marker/action';
 import { initHistory } from '../../store/history/action';
+import { getInitialMarkersFromLocalStorage } from '../../utils/updateMarkerStorage';
 
 export interface MapHookType {
   containerRef: RefObject<HTMLDivElement>;
@@ -28,7 +27,11 @@ interface ReduxStateType {
   marker: MarkerState;
 }
 
-function useMap(): MapHookType {
+interface UseMapProps {
+  registerMarker: ({ id, text, lngLat, instance }: RegisterMarkerType) => void;
+}
+
+function useMap({ registerMarker }: UseMapProps): MapHookType {
   const dispatch = useDispatch();
   const containerRef = useRef<HTMLDivElement>(null);
   const afterMapRef = useRef<HTMLDivElement>(null);
@@ -43,8 +46,7 @@ function useMap(): MapHookType {
 
   const { changeStyle, replaceStyle } = useWholeStyle();
   const [flag, setFlag] = useState(false);
-  const { search, pathname } = window.location;
-  const { registerMarker } = useMarkerFeature();
+  const { pathname } = window.location;
 
   const initializeMap = (map: mapboxgl.Map): void => {
     const { filteredStyle, mapCoordinate } = urlToJson();
@@ -52,6 +54,7 @@ function useMap(): MapHookType {
     if (validateStyle(filteredStyle as WholeStyleActionPayload)) {
       changeStyle(filteredStyle as WholeStyleActionPayload);
     } else {
+      // eslint-disable-next-line no-alert
       alert('URL에 잘못된 속성이 포함되어 있습니다.');
     }
 
@@ -99,7 +102,6 @@ function useMap(): MapHookType {
   }, [flag]);
 
   useEffect(() => {
-    console.log('called');
     dispatch(initMap(afterMapRef, initializeMap));
   }, []);
 

--- a/src/hooks/sidebar/useStyleType.ts
+++ b/src/hooks/sidebar/useStyleType.ts
@@ -16,11 +16,11 @@ import { setStyle, initColors } from '../../store/style/action';
 import * as mapStyling from '../../utils/map-styling';
 
 import { hexToHSL, hslToHEX } from '../../utils/colorFormat';
-import useHistoryFeature from '../map/useHistoryFeature';
 import { VisibilityType } from '../../utils/applyStyle';
 import { getDefaultStyle } from '../../store/style/properties';
 import removeNullFromObject from '../../utils/removeNullFromObject';
 import deepCopy from '../../utils/deepCopy';
+import { addLog } from '../../store/history/action';
 
 export interface UseStyleHookType {
   styleElement: StyleType;
@@ -64,7 +64,6 @@ interface changedObjType {
 function useStyleType(): UseStyleHookType {
   const dispatch = useDispatch();
   const [changedObj, setChangedObj] = useState<changedObjType>({});
-  const { addHistory } = useHistoryFeature();
   const {
     map,
     sidebar: { feature, subFeature, element, subElement },
@@ -91,7 +90,7 @@ function useStyleType(): UseStyleHookType {
   useEffect(() => {
     const { key, value } = changedObj;
     if (key && value && feature && subFeature && element) {
-      addHistory({
+      const info = {
         changedKey: key,
         changedValue: value,
         feature,
@@ -103,8 +102,8 @@ function useStyleType(): UseStyleHookType {
           [key]: value,
         },
         wholeStyle: removeNullFromObject(deepCopy(features)) as StyleStoreType,
-      });
-
+      };
+      dispatch(addLog(info));
       setChangedObj({});
     }
   }, [changedObj]);

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -20,6 +20,7 @@ const MainWrapper = styled.div`
   align-items: center;
   width: 100%;
   height: 100%;
+  min-width: 500px;
 `;
 
 function Main({ location: { pathname } }: MainProps): React.ReactElement {

--- a/src/store/history/reducer.ts
+++ b/src/store/history/reducer.ts
@@ -9,7 +9,6 @@ import {
   HistoryActionType,
   HistoryInfoPropsType,
   SetIndexPayload,
-  objType,
 } from '../common/type';
 import getRandomId from '../../utils/getRandomId';
 import deepCopy from '../../utils/deepCopy';

--- a/src/store/map/initializeMap.ts
+++ b/src/store/map/initializeMap.ts
@@ -33,9 +33,8 @@ function initializingMap({
   const geocoder = new MapboxGeocoder({
     accessToken: mapboxgl.accessToken,
     placeholder: '검색할 장소를 입력하세요',
+    mapboxgl,
   });
-
-  document.getElementById('search-bar')?.appendChild(geocoder.onAdd(map));
 
   map.addControl(
     new mapboxgl.GeolocateControl({
@@ -49,6 +48,7 @@ function initializingMap({
 
   map.on('load', () => {
     initializeMap(map);
+    document.getElementById('search-bar')?.appendChild(geocoder.onAdd(map));
   });
 
   return map;

--- a/src/utils/rendering-data/defaultStyle.ts
+++ b/src/utils/rendering-data/defaultStyle.ts
@@ -144,7 +144,7 @@ const defaultStyle: DefaultWholeStyle = {
     country: {
       section: {
         fill: { color: 'transparent', weight: 0 },
-        stroke: { color: 'hsl(230, 8%, 51%)', weight: 7 },
+        stroke: { color: 'hsl(230, 8%, 51%)', weight: 3 },
       },
       labelText: {
         fill: { color: 'hsl(0, 0%, 0%)', weight: 0 },
@@ -154,7 +154,7 @@ const defaultStyle: DefaultWholeStyle = {
     state: {
       section: {
         fill: { color: 'transparent', weight: 0 },
-        stroke: { color: 'hsl(230, 14%, 77%)', weight: 7 },
+        stroke: { color: 'hsl(230, 14%, 77%)', weight: 3 },
       },
       labelText: {
         fill: { color: 'hsl(0, 0%, 0%)', weight: 0 },

--- a/src/utils/rendering-data/theme/christmas.json
+++ b/src/utils/rendering-data/theme/christmas.json
@@ -1,160 +1,165 @@
 {
-	"poi":{
-		 "all":{
-				"labelText":{
-					 "fill":{
-							"visibility":"none",
-							"color":"#d96459",
-							"saturation":63,
-							"lightness":60
-					 }
-				}
-		 }
-	},
-	"landscape":{
-		 "all":{
-				"section":{
-					 "fill":{
-							"color":"#588c73",
-							"saturation":23,
-							"lightness":45
-					 }
-				},
-				"labelText":{
-					 "fill":{
-							"color":"#eea36e",
-							"saturation":79,
-							"lightness":68
-					 }
-				}
-		 },
-		 "humanmade":{
-				"section":{
-					 "fill":{
-							"color":"#d96459",
-							"saturation":63,
-							"lightness":60
-					 }
-				}
-		 },
-		 "building":{
-				"section":{
-					 "fill":{
-							"color":"#d96459",
-							"saturation":63,
-							"lightness":60
-					 }
-				},
-				"labelText":{
-					 "fill":{
-							"visibility":"none"
-					 }
-				}
-		 }
-	},
-	"administrative":{
-		 "all":{
-				"section":{
-					 "stroke":{
-							"color":"#d96459",
-							"weight":2,
-							"saturation":63,
-							"lightness":60
-					 }
-				},
-				"labelText":{
-					 "fill":{
-							"color":"#d96459",
-							"saturation":63,
-							"lightness":60
-					 },
-					 "stroke":{
-							"color":"#eea36e",
-							"saturation":79,
-							"lightness":68
-					 }
-				}
-		 }
-	},
-	"road":{
-		 "all":{
-				"section":{
-					 "fill":{
-							"visibility":"none",
-							"saturation":47,
-							"lightness":47
-					 },
-					 "stroke":{
-							"visibility":"visible",
-							"color":"#fafafa",
-							"weight":0.5,
-							"lightness":98
-					 }
-				},
-				"labelText":{
-					 "fill":{
-							"color":"#f7f8fd",
-							"saturation":60,
-							"lightness":98
-					 },
-					 "stroke":{
-							"visibility":"none",
-							"color":"#fafafa",
-							"lightness":98
-					 }
-				},
-				"labelIcon":{
-					 "visibility":"none"
-				}
-		 }
-	},
-	"transit":{
-		 "all":{
-				"section":{
-					 "stroke":{
-							"color":"#ffffff",
-							"lightness":100
-					 }
-				},
-				"labelText":{
-					 "fill":{
-							"color":"#eea36e",
-							"saturation":79,
-							"lightness":68
-					 },
-					 "stroke":{
-							"color":"#ffffff",
-							"lightness":100
-					 }
-				}
-		 },
-		 "airport":{
-				"section":{
-					 "fill":{
-							"color":"#ffffff"
-					 },
-					 "stroke":{
-							"color":"#ffffff"
-					 }
-				},
-				"labelText":{
-					 "fill":{
-							"color":"#eea36e",
-							"saturation":79,
-							"lightness":68
-					 }
-				}
-		 }
-	},
-	"water":{
-		 "all":{
-				"section":{
-					 "fill":{
-							"color":"#fafafa",
-							"saturation":0,
-							"lightness":98
-					 }
-				}
-		 }
-	}
+  "poi": {
+    "all": {
+      "labelText": {
+        "fill": {
+          "visibility": "none",
+          "color": "#d96459",
+          "saturation": 63,
+          "lightness": 60
+        }
+      }
+    }
+  },
+  "landscape": {
+    "all": {
+      "section": {
+        "fill": {
+          "color": "#588c73",
+          "saturation": 23,
+          "lightness": 45
+        }
+      },
+      "labelText": {
+        "fill": {
+          "color": "#eea36e",
+          "saturation": 79,
+          "lightness": 68
+        }
+      }
+    },
+    "humanmade": {
+      "section": {
+        "fill": {
+          "color": "#d96459",
+          "saturation": 63,
+          "lightness": 60
+        }
+      }
+    },
+    "building": {
+      "section": {
+        "fill": {
+          "color": "#d96459",
+          "saturation": 63,
+          "lightness": 60
+        }
+      },
+      "labelText": {
+        "fill": {
+          "visibility": "none"
+        }
+      }
+    }
+  },
+  "administrative": {
+    "all": {
+      "section": {
+        "stroke": {
+          "color": "#d96459",
+          "weight": 2,
+          "saturation": 63,
+          "lightness": 60
+        }
+      },
+      "labelText": {
+        "fill": {
+          "color": "#d96459",
+          "saturation": 63,
+          "lightness": 60
+        },
+        "stroke": {
+          "color": "#eea36e",
+          "saturation": 79,
+          "lightness": 68
+        }
+      }
+    }
+  },
+  "road": {
+    "all": {
+      "section": {
+        "fill": {
+          "visibility": "none",
+          "saturation": 47,
+          "lightness": 47
+        },
+        "stroke": {
+          "visibility": "visible",
+          "color": "#fafafa",
+          "weight": 0.5,
+          "lightness": 98
+        }
+      },
+      "labelText": {
+        "fill": {
+          "color": "#f7f8fd",
+          "saturation": 60,
+          "lightness": 98
+        },
+        "stroke": {
+          "visibility": "none",
+          "color": "#fafafa",
+          "lightness": 98
+        }
+      },
+      "labelIcon": {
+        "visibility": "none"
+      }
+    }
+  },
+  "transit": {
+    "all": {
+      "section": {
+        "stroke": {
+          "color": "#ffffff",
+          "lightness": 100
+        }
+      },
+      "labelText": {
+        "fill": {
+          "color": "#eea36e",
+          "saturation": 79,
+          "lightness": 68
+        },
+        "stroke": {
+          "color": "#ffffff",
+          "lightness": 100
+        }
+      }
+    },
+    "airport": {
+      "section": {
+        "fill": {
+          "color": "#ffffff"
+        },
+        "stroke": {
+          "color": "#ffffff"
+        }
+      },
+      "labelText": {
+        "fill": {
+          "color": "#eea36e",
+          "saturation": 79,
+          "lightness": 68
+        }
+      }
+    }
+  },
+  "water": {
+    "all": {
+      "section": {
+        "fill": {
+          "color": "#fafafa",
+          "saturation": 0,
+          "lightness": 98
+        }
+      },
+      "labelText": {
+        "fill": {
+          "visibility": "none"
+        }
+      }
+    }
+  }
 }

--- a/src/utils/rendering-data/theme/monochrome.json
+++ b/src/utils/rendering-data/theme/monochrome.json
@@ -66,7 +66,7 @@
       },
       "labelText": {
         "fill": {
-          "visibility": "9cfcd2"
+          "visibility": "visible"
         },
         "stroke": {
           "color": "#070808"

--- a/src/utils/updateMarkerStorage.ts
+++ b/src/utils/updateMarkerStorage.ts
@@ -1,0 +1,80 @@
+import mapboxgl from 'mapbox-gl';
+import { MarkerInstanceType, MARKER } from '../store/marker/action';
+
+const initialLocalStorageMarkers: MarkerInstanceType[] = [];
+
+const getMarkersFromLocalStorage = (): MarkerInstanceType[] => {
+  return JSON.parse(localStorage.getItem(MARKER) as string);
+};
+
+const setMarkersToLocalStorage = (markers: MarkerInstanceType[]): void => {
+  localStorage.setItem(MARKER, JSON.stringify(markers));
+};
+
+export function getInitialMarkersFromLocalStorage(): MarkerInstanceType[] {
+  const storedMarkers = getMarkersFromLocalStorage();
+
+  if (!storedMarkers) return initialLocalStorageMarkers;
+
+  const newState = storedMarkers.reduce(
+    (
+      acc: MarkerInstanceType[],
+      marker: MarkerInstanceType
+    ): MarkerInstanceType[] => {
+      const newMarker = new mapboxgl.Marker({
+        draggable: true,
+      })
+        .setLngLat([marker.lng, marker.lat])
+        .setPopup(new mapboxgl.Popup().setHTML(`<p>${marker.text}</p>`));
+      acc.push({ ...marker, instance: newMarker });
+      return acc;
+    },
+    []
+  );
+
+  return newState;
+}
+
+export function setNewMarkerToLocalStorage({
+  id,
+  text,
+  lng,
+  lat,
+}: MarkerInstanceType): void {
+  const storedMarker = getMarkersFromLocalStorage();
+  const markerArray = storedMarker ?? [];
+
+  markerArray.push({
+    id,
+    text,
+    lng,
+    lat,
+  });
+
+  setMarkersToLocalStorage(markerArray);
+}
+
+export function updateMarkerOfLocalStorage({
+  id,
+  lng,
+  lat,
+}: MarkerInstanceType): void {
+  const storedMarkers = getMarkersFromLocalStorage();
+  const changedMarkers = storedMarkers.map((marker) => {
+    const targetMarker =
+      marker.id === id
+        ? { ...marker, lng: lng ?? marker.lng, lat: lat ?? marker.lat }
+        : marker;
+    return targetMarker;
+  });
+
+  setMarkersToLocalStorage(changedMarkers);
+}
+
+export function deleteMarkerOfLocalStorage(id: string): void {
+  const storedMarkers = getMarkersFromLocalStorage();
+  const targetMarker = storedMarkers.find((marker) => marker.id === id);
+  targetMarker?.instance?.remove();
+  const changedMarkers = storedMarkers.filter((marker) => marker.id !== id);
+  setMarkersToLocalStorage(changedMarkers);
+}


### PR DESCRIPTION
## 수정사항
- hook을 함수처럼 가져다쓰다보니 불필요한 useEffect가 많이 일어남(useEffect의 deps에 redux 상태 포함 때문)
- 위와 같은 불필요한 useEffect 방지를 위해 리팩토링
  - useMarkerFeature, useHistoryFeature, useHistoryMap
- 비교하기 지도 미리 만들기
  - 기존의 형태는 beforeMap을 비교하기 실행시마다 다시 만들어주는 형태
  - 미리 만들어둔 beforeMap을 사용하는 방식으로 수정
- 테마 속성과 맞지 않는 값 수정
- 초기 렌더시 marker 관련 에러 fix