### PR TITLE
Undo/Redo 전체 색상 초기화 처리

### DIFF
--- a/src/hooks/sidebar/useInitAllColor.ts
+++ b/src/hooks/sidebar/useInitAllColor.ts
@@ -1,0 +1,68 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../store';
+import { initColors } from '../../store/style/action';
+import { getDefaultStyle } from '../../store/style/properties';
+import * as mapStyling from '../../utils/map-styling';
+import {
+  FeatureNameType,
+  ElementNameType,
+  SubElementNameType,
+  StyleType,
+  StyleKeyType,
+  StyleStoreType,
+} from '../../store/common/type';
+
+interface InitAllColorProps {
+  features: StyleStoreType;
+  feature: FeatureNameType;
+  element: ElementNameType;
+  subElement: SubElementNameType;
+  style: StyleType;
+  key: StyleKeyType;
+}
+
+interface useInitAllColorHookType {
+  initAllColor: (props: InitAllColorProps) => void;
+}
+
+function useInitAllColor(): useInitAllColorHookType {
+  const dispatch = useDispatch();
+  const map = useSelector<RootState>((state) => state.map.map) as mapboxgl.Map;
+
+  const initAllColor = ({
+    features,
+    feature,
+    element,
+    subElement,
+    style,
+    key,
+  }: InitAllColorProps) => {
+    dispatch(initColors(feature, element, subElement));
+    Object.keys(features[feature]).forEach((subFeatureName) => {
+      const defaulStyle = getDefaultStyle({
+        feature,
+        subFeature: subFeatureName,
+        element,
+        subElement,
+      });
+
+      mapStyling[feature]({
+        map,
+        subFeature: subFeatureName,
+        key,
+        element,
+        subElement,
+        style: {
+          ...style,
+          color: defaulStyle.color,
+        },
+      });
+    });
+  };
+
+  return {
+    initAllColor,
+  };
+}
+
+export default useInitAllColor;

--- a/src/hooks/sidebar/useStyleType.ts
+++ b/src/hooks/sidebar/useStyleType.ts
@@ -12,7 +12,7 @@ import {
   ReduxStateType,
   StyleStoreType,
 } from '../../store/common/type';
-import { setStyle, initColors } from '../../store/style/action';
+import { setStyle } from '../../store/style/action';
 import * as mapStyling from '../../utils/map-styling';
 
 import { hexToHSL, hslToHEX } from '../../utils/colorFormat';
@@ -21,6 +21,7 @@ import { getDefaultStyle } from '../../store/style/properties';
 import removeNullFromObject from '../../utils/removeNullFromObject';
 import deepCopy from '../../utils/deepCopy';
 import { addLog } from '../../store/history/action';
+import useInitAllColor from './useInitAllColor';
 
 export interface UseStyleHookType {
   styleElement: StyleType;
@@ -76,6 +77,7 @@ function useStyleType(): UseStyleHookType {
       features,
     };
   }) as ReduxStateType;
+  const { initAllColor } = useInitAllColor();
 
   const styleElement = useSelector<RootState>((state) => {
     if (!feature || !subFeature || !element) {
@@ -155,27 +157,16 @@ function useStyleType(): UseStyleHookType {
 
       /** all의 색상을 바꿀 때 */
       if (value === initColor && subFeature === 'all' && subElement) {
-        dispatch(initColors(feature, element, subElement));
-        Object.keys(features[feature]).forEach((subFeatureName) => {
-          const style = getDefaultStyle({
-            feature,
-            subFeature: subFeatureName,
-            element,
-            subElement,
-          });
-
-          mapStyling[feature]({
-            map,
-            subFeature: subFeatureName,
-            key: newStyleKey,
-            element,
-            subElement: subElement as SubElementNameType,
-            style: {
-              ...styleElement,
-              ...newStyleObj,
-              color: style.color,
-            },
-          });
+        initAllColor({
+          features,
+          feature,
+          element,
+          subElement,
+          style: {
+            ...styleElement,
+            ...newStyleObj,
+          },
+          key: newStyleKey,
         });
         setChangedObj({
           key,

--- a/src/hooks/sidebar/useUndoRedo.ts
+++ b/src/hooks/sidebar/useUndoRedo.ts
@@ -18,6 +18,7 @@ import { setStyle } from '../../store/style/action';
 import { initDepthTheme } from '../../store/depth-theme/action';
 import * as mapStyling from '../../utils/map-styling';
 import useWholeStyle from '../common/useWholeStyle';
+import useInitAllColor from './useInitAllColor';
 
 interface UseUndoRedoType {
   undoHandler: () => void;
@@ -36,6 +37,7 @@ function useUndoRedo(): UseUndoRedoType {
     log: state.history.log,
     currentIdx: state.history.currentIdx,
   })) as ReduxStateType;
+  const { initAllColor } = useInitAllColor();
 
   const undoHandler = () => {
     if (!map || !log || currentIdx === null || currentIdx < 0) return;
@@ -62,7 +64,7 @@ function useUndoRedo(): UseUndoRedoType {
         ? StyleKeyType.color
         : changedKey;
 
-    let beforeStyle;
+    let beforeStyle: StyleType;
     if (currentIdx === 0) {
       beforeStyle = subElement
         ? getDefaultStyle({
@@ -74,12 +76,29 @@ function useUndoRedo(): UseUndoRedoType {
         : getDefaultStyle({ feature, subFeature, element });
     } else {
       const { wholeStyle } = log[undoIdx];
-      beforeStyle =
-        subElement && wholeStyle
-          ? (wholeStyle[feature][subFeature][element] as SubElementType)[
-              subElement
-            ]
-          : wholeStyle[feature][subFeature][element];
+      beforeStyle = (subElement && wholeStyle
+        ? (wholeStyle[feature][subFeature][element] as SubElementType)[
+            subElement
+          ]
+        : wholeStyle[feature][subFeature][element]) as StyleType;
+    }
+
+    /** All color 초기화 상태로 돌리는 경우 */
+    if (
+      changedKey === StyleKeyType.color &&
+      subFeature === 'all' &&
+      beforeStyle.color === 'transparent'
+    ) {
+      const { wholeStyle } = currentIdx === 0 ? log[currentIdx] : log[undoIdx];
+      initAllColor({
+        features: wholeStyle,
+        feature,
+        element,
+        subElement: subElement as SubElementNameType,
+        style: beforeStyle,
+        key: changedKey,
+      });
+      return;
     }
 
     /** 변경된 사항만 그리는 경우 */
@@ -124,6 +143,24 @@ function useUndoRedo(): UseUndoRedoType {
       changedKey === ColorSubStyleType.lightness
         ? StyleKeyType.color
         : changedKey;
+
+    /** All color 초기화 상태로 돌리는 경우 */
+    if (
+      changedKey === StyleKeyType.color &&
+      subFeature === 'all' &&
+      style.color === 'transparent'
+    ) {
+      const { wholeStyle } = log[redoIdx]; // 이거 맞을까오...
+      initAllColor({
+        features: wholeStyle,
+        feature,
+        element,
+        subElement: subElement as SubElementNameType,
+        style,
+        key: changedKey,
+      });
+      return;
+    }
 
     /** 변경된 사항에만 그리는 경우 */
     mapStyling[feature]({


### PR DESCRIPTION
- 기존 useStyleType에서 전체 색상 초기화 부분을 분리해서 별도의 Hook으로 만들었습니다.
- Undo/Redo의 상태가 전체 색상 초기화 인 경우에 위의 분리된 Hook을 사용하여 처리하였습니다.