### PR TITLE
history reset 시 sidebar도 초기화 / 버그에 대한 setFeatureStyle 분기문 추가 

### DIFF
--- a/src/hooks/common/useWholeStyle.ts
+++ b/src/hooks/common/useWholeStyle.ts
@@ -29,7 +29,7 @@ interface WholeStyleHook {
     inputStyle: WholeStyleActionPayload,
     logInfo?: LogInfoType
   ) => void;
-  replaceStyle: (inputStyle: StyleStoreType, logInfo?: LogInfoType) => void;
+  replaceStyle: (inputStyle: StyleStoreType) => void;
 }
 
 function useWholeStyle(): WholeStyleHook {

--- a/src/hooks/map/useHistoryFeature.ts
+++ b/src/hooks/map/useHistoryFeature.ts
@@ -2,6 +2,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../store/index';
 import { resetHistory } from '../../store/history/action';
+import { initDepthTheme } from '../../store/depth-theme/action';
 
 // Type
 import { HistoryState, HistoryInfoPropsType } from '../../store/common/type';
@@ -25,6 +26,7 @@ function useHistoryFeature(): useHistoryFeatureType {
 
   const resetHistoryAndStyle = () => {
     dispatch(resetHistory());
+    dispatch(initDepthTheme());
     changeStyle({});
   };
 

--- a/src/utils/setFeatureStyle.ts
+++ b/src/utils/setFeatureStyle.ts
@@ -89,7 +89,7 @@ function setElementStyle({
   style,
   isInit,
 }: setElementStyleProps): void {
-  // if (!isInit) return;
+  if (!style.isChanged && !isInit) return;
   const keys = Object.keys(style) as StyleKeyType[];
   keys.forEach((key) => {
     if (key === 'color' && style[key] === 'transparent') {


### PR DESCRIPTION
- history reset 시 sidebar도 초기화
-  setFeatureStyle 분기문 추가
    - 하위 요소 스타일을 변경했을때 상위요소 스타일에 의해 적절하게 적용이 되지 않는 문제 fix
    - 단 세부 카테고리를 조정하고 테마를 적용하였을때 undo시 테마의 스타일이
남아있는 bug 존재